### PR TITLE
Add tab layout

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,9 +25,11 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:28.0.0-rc01'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
-    implementation 'com.google.firebase:firebase-auth:15.0.0'
+    implementation 'com.android.support:appcompat-v7:28.0.0-rc2'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+    implementation 'com.android.support:design:28.0.0-rc01'
+    implementation 'com.google.firebase:firebase-auth:16.0.3'
+    implementation 'com.android.support:support-v13:28.0.0-rc02'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="intern.line.tokyoaclient">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -9,7 +11,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-	android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="true">
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -23,7 +25,7 @@
         <activity android:name=".ImageDebugActivity" />
         <activity android:name=".FriendListActivity" />
         <activity android:name=".AddFriendActivity" />
+        <activity android:name=".TabLayoutActivity"></activity>
     </application>
-    <uses-permission android:name="android.permission.INTERNET" />
 
 </manifest>

--- a/app/src/main/java/intern/line/tokyoaclient/FriendListFragment.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/FriendListFragment.kt
@@ -1,0 +1,120 @@
+package intern.line.tokyoaclient
+
+
+import android.content.Intent
+import android.os.Bundle
+import android.support.v4.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.ListView
+import android.widget.TextView
+import android.widget.Toast
+import intern.line.tokyoaclient.HttpConnection.friendService
+import intern.line.tokyoaclient.HttpConnection.userProfileService
+import rx.android.schedulers.AndroidSchedulers
+import rx.schedulers.Schedulers
+import java.util.*
+
+
+// TODO: Rename parameter arguments, choose names that match
+// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+// private const val ARG_PARAM1 = "param1"
+
+private lateinit var friendList: ListView
+private lateinit var addFriendButton: Button
+private var adapter: UserListAdapter? = null
+
+private lateinit var userId: String
+
+class FriendListFragment : Fragment() {
+    private lateinit var v: View
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
+                              savedInstanceState: Bundle?): View? {
+        // Inflate the layout for this fragment
+        v = inflater.inflate(R.layout.fragment_friend_list, container, false)
+        //MyPagerAdapterで設定しておいたargumentsを取得
+        userId = arguments!!.getString("userId")
+        addFriendButton = v.findViewById(R.id.addFriendButton) as Button
+        friendList = v.findViewById(R.id.friendList) as ListView
+
+        adapter = UserListAdapter(context!!, ArrayList())
+        friendList.setAdapter(adapter)
+
+        getOwnName(userId)
+        getFriend(userId)
+
+        addFriendButton.setOnClickListener {
+            goToAddFriend(userId)
+        }
+        friendList.setOnItemClickListener { adapterView, view, position, id ->
+            val friendId = view.findViewById<TextView>(R.id.idTextView).text.toString()
+            val num1: Int = Math.abs(UUID.nameUUIDFromBytes(userId.toByteArray()).hashCode())
+            val num2: Int = Math.abs(UUID.nameUUIDFromBytes(friendId.toByteArray()).hashCode())
+            val roomId: Int = num1 + num2
+            goToTalk(roomId)
+        }
+        return v
+    }
+
+    private fun getFriend(userId: String) {
+        adapter?.clear()
+        friendService.getFriendById(userId)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                    for (s in it) {
+                        getFriendName(s.friendId)
+                    }
+                    Toast.makeText(context, "get friend list succeeded", Toast.LENGTH_SHORT).show()
+                    println("get friend list succeeded: $it")
+                }, {
+                    Toast.makeText(context, "get friend list failed: $it", Toast.LENGTH_LONG).show()
+                    println("get friend list failed: $it")
+                })
+    }
+
+    private fun getOwnName(idStr: String) { // idを引数に、nameをゲットする関数。ユーザー情報のGET/POSTメソッドはどっかに分離したほうがわかりやすそう。
+        userProfileService.getUserById(idStr)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                    Toast.makeText(context, "get name succeeded", Toast.LENGTH_SHORT).show()
+                    println("get name succeeded: $it")
+                    (v.findViewById(R.id.ownNameText) as TextView).text = "Hello, ${it.name}!"
+                }, {
+                    Toast.makeText(context, "get name failed: $it", Toast.LENGTH_LONG).show()
+                    println("get name failed: $it")
+                })
+    }
+
+    private fun getFriendName(friendId: String) { // idを引数に、nameをゲットする関数。ユーザー情報のGET/POSTメソッドはどっかに分離したほうがわかりやすそう。
+        userProfileService.getUserById(friendId)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                    Toast.makeText(context, "get name succeeded", Toast.LENGTH_SHORT).show()
+                    println("get name succeeded: $it")
+                    adapter?.addAll(it)
+                }, {
+                    Toast.makeText(context, "get name failed: $it", Toast.LENGTH_LONG).show()
+                    println("get name failed: $it")
+                })
+    }
+
+    private fun goToAddFriend(userId: String) {
+        val intent = Intent(context, AddFriendActivity::class.java)
+        intent.putExtra("userId", userId)
+        startActivity(intent)
+    }
+
+    private fun goToTalk(roomId: Int) {
+        val intent = Intent(context, TalkActivity::class.java)
+        intent.putExtra("userId", userId)
+        intent.putExtra("roomId", roomId.toString())
+        startActivity(intent)
+    }
+
+}

--- a/app/src/main/java/intern/line/tokyoaclient/HttpConnection/RetrofitInstance.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/HttpConnection/RetrofitInstance.kt
@@ -30,3 +30,4 @@ val userProfileService: UserProfileService = retrofit.create(UserProfileService:
 val talkService: TalkService = retrofit.create(TalkService::class.java)
 val imageService: ImageService = retrofit.create(ImageService::class.java)
 val friendService: FriendService = retrofit.create(FriendService::class.java)
+val roomService: RoomService = retrofit.create(RoomService::class.java)

--- a/app/src/main/java/intern/line/tokyoaclient/HttpConnection/service/RoomService.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/HttpConnection/service/RoomService.kt
@@ -1,0 +1,44 @@
+package intern.line.tokyoaclient.HttpConnection.service
+
+import intern.line.tokyoaclient.HttpConnection.model.Room
+import intern.line.tokyoaclient.HttpConnection.model.RoomMember
+import retrofit2.http.*
+import rx.Completable
+import rx.Single
+
+interface RoomService {
+    //Room
+    @GET("/room")
+    fun getAllRoom(): Single<List<Room>>
+
+    @GET("/room/room_id/{room_id}")
+    fun findByRoomId(@Path("room_id") roomId: String): Single<Room>
+
+    @POST("/room/create/{room_name}")
+    fun addRoom(@Path("room_name") roomName: String): Completable
+
+    @PUT("/room/modify/{room_id}/{room_name}")
+    fun modifyroom(@Path("room_id") roomId: String, @Path("room_name") roomName: String): Completable
+
+    @DELETE("/user/delete/{room_id}")
+    fun deleteUser(@Path("room_id") roomId: String): Single<Room>
+
+    //Room Member
+    @GET("/room_member")
+    fun getAllRoomMembers(): Single<List<RoomMember>>
+
+    @GET("/room_member/room_id/{room_id}")
+    fun getRoomMembersByRoomId(@Path("room_id") roomId: String): Single<List<RoomMember>>
+
+    @GET("/room_member/uid/{uid}")
+    fun getRoomsByUserId(@Path("uid") uid: String): Single<List<RoomMember>>
+
+    @POST("/room_member/create/{room_id}/{uid}")
+    fun addRoomMember(@Path("room_id") roomId: String, @Path("uid") uid: String): Completable
+
+    @DELETE("/user/delete/{room_id}")
+    fun deleteAllRoomMembers(@Path("room_id") roomId: String): Single<List<RoomMember>>
+
+    @DELETE("/user/delete/{room_id}/{uid}")
+    fun deleteMember(@Path("room_id") roomId: String, @Path("uid") uid: String): Single<List<RoomMember>>
+}

--- a/app/src/main/java/intern/line/tokyoaclient/HttpConnection/service/UserProfileService.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/HttpConnection/service/UserProfileService.kt
@@ -27,5 +27,4 @@ interface UserProfileService {
 
     @DELETE("/user/delete/{id}")
     fun deleteUser(@Path("id") id: String): Single<UserProfile>
-
 }

--- a/app/src/main/java/intern/line/tokyoaclient/MainActivity.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/MainActivity.kt
@@ -110,13 +110,13 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun intent(uid: String) {
-        var intent = Intent(this, FriendListActivity::class.java)
+        var intent = Intent(this, TabLayoutActivity::class.java)
         intent.putExtra("userId", uid)
         startActivity(intent)
     }
 
     private fun goTest() {
-        var intent = Intent(this, AddFriendActivity::class.java)
+        var intent = Intent(this, TabLayoutActivity::class.java)
         //intent.putExtra("userId", uid)
         startActivity(intent)
     }

--- a/app/src/main/java/intern/line/tokyoaclient/MyPagerAdapter.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/MyPagerAdapter.kt
@@ -1,0 +1,46 @@
+package intern.line.tokyoaclient
+
+import android.os.Bundle
+import android.support.v4.app.Fragment
+import android.support.v4.app.FragmentManager
+import android.support.v4.app.FragmentPagerAdapter
+
+class MyPagerAdapter(fm: FragmentManager, uid: String) : FragmentPagerAdapter(fm) {
+    val bundle = Bundle()
+    val userId: String = uid
+
+    override fun getItem(position: Int): Fragment {
+        bundle.putString("userId",userId)
+        when (position) {
+            0 -> {
+                val frg = FriendListFragment()
+                frg.setArguments(bundle)
+                return frg
+            }
+            1 -> {
+                val frg = TalkListFragment()
+                frg.setArguments(bundle)
+                return frg
+            }
+            else -> {
+                val frg = SettingFragment()
+                frg.setArguments(bundle)
+                return frg
+            }
+        }
+    }
+
+    override fun getCount(): Int {
+        return 3
+    }
+
+    override fun getPageTitle(position: Int): CharSequence {
+        return when (position) {
+            0 -> "Friend List"
+            1 -> "Talk List"
+            else -> {
+                return "Settings"
+            }
+        }
+    }
+}

--- a/app/src/main/java/intern/line/tokyoaclient/SettingFragment.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/SettingFragment.kt
@@ -1,0 +1,29 @@
+package intern.line.tokyoaclient
+
+
+import android.os.Bundle
+import android.support.v4.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+
+
+// TODO: Rename parameter arguments, choose names that match
+// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+private const val ARG_PARAM1 = "param1"
+private const val ARG_PARAM2 = "param2"
+
+/**
+ * A simple [Fragment] subclass.
+ *
+ */
+class SettingFragment : Fragment() {
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
+                              savedInstanceState: Bundle?): View? {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_setting, container, false)
+    }
+
+
+}

--- a/app/src/main/java/intern/line/tokyoaclient/TabLayoutActivity.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/TabLayoutActivity.kt
@@ -1,0 +1,17 @@
+package intern.line.tokyoaclient
+
+import android.support.v7.app.AppCompatActivity
+import android.os.Bundle
+import kotlinx.android.synthetic.main.activity_tab_layout.*
+
+class TabLayoutActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_tab_layout)
+        val userId = intent.getStringExtra("userId")
+        val fragmentAdapter = MyPagerAdapter(supportFragmentManager, userId)
+        viewpager_main.adapter = fragmentAdapter
+        tabs_main.setupWithViewPager(viewpager_main)
+    }
+}

--- a/app/src/main/java/intern/line/tokyoaclient/TalkListActivity.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/TalkListActivity.kt
@@ -1,0 +1,107 @@
+//package intern.line.tokyoaclient
+//
+//import android.content.Intent
+//import android.os.Bundle
+//import android.support.v7.app.AppCompatActivity
+//import android.widget.Button
+//import android.widget.ListView
+//import android.widget.TextView
+//import android.widget.Toast
+//import intern.line.tokyoaclient.HttpConnection.friendService
+//import intern.line.tokyoaclient.HttpConnection.userProfileService
+//import rx.android.schedulers.AndroidSchedulers
+//import rx.schedulers.Schedulers
+//import java.util.*
+//
+//class TalkListActivity : AppCompatActivity() {
+//
+//    private lateinit var talkList: ListView
+//    private lateinit var addGroupButton: Button
+//    private var adapter: TalkListAdapter? = null
+//
+//    private lateinit var userId: String
+//
+//    override fun onCreate(savedInstanceState: Bundle?) {
+//        super.onCreate(savedInstanceState)
+//        setContentView(R.layout.activity_friend_list)
+//
+//        userId = intent.getStringExtra("userId")
+//        addGroupButton = findViewById(R.id.addFriendButton) as Button
+//        talkList = findViewById(R.id.friendList) as ListView
+//
+//        adapter = UserListAdapter(this, ArrayList())
+//        talkList.setAdapter(adapter)
+//
+//        getOwnName(userId)
+//        getFriend(userId)
+//
+//        addGroupButton.setOnClickListener {
+//            goToAddFriend(userId)
+//        }
+//        talkList.setOnItemClickListener { adapterView, view, position, id ->
+//            val friendId = view.findViewById<TextView>(R.id.idTextView).text.toString()
+//            val num1: Int = Math.abs(UUID.nameUUIDFromBytes(userId.toByteArray()).hashCode())
+//            val num2: Int = Math.abs(UUID.nameUUIDFromBytes(friendId.toByteArray()).hashCode())
+//            val roomId: Int = num1+num2
+//            goToTalk(roomId)
+//        }
+//    }
+//
+//    private fun getFriend(userId: String) {
+//        adapter?.clear()
+//        friendService.getFriendById(userId)
+//                .subscribeOn(Schedulers.io())
+//                .observeOn(AndroidSchedulers.mainThread())
+//                .subscribe({
+//                    for (s in it) {
+//                        getFriendName(s.friendId)
+//                    }
+//                    Toast.makeText(this, "get friend list succeeded", Toast.LENGTH_SHORT).show()
+//                    println("get friend list succeeded: $it")
+//                }, {
+//                    Toast.makeText(this, "get friend list failed: $it", Toast.LENGTH_LONG).show()
+//                    println("get friend list failed: $it")
+//                })
+//    }
+//
+//    private fun getOwnName(idStr: String) { // idを引数に、nameをゲットする関数。ユーザー情報のGET/POSTメソッドはどっかに分離したほうがわかりやすそう。
+//        userProfileService.getUserById(idStr)
+//                .subscribeOn(Schedulers.io())
+//                .observeOn(AndroidSchedulers.mainThread())
+//                .subscribe({
+//                    Toast.makeText(this, "get name succeeded", Toast.LENGTH_SHORT).show()
+//                    println("get name succeeded: $it")
+//                    (findViewById(R.id.ownNameText) as TextView).text = "Hello, ${it.name}!"
+//                }, {
+//                    Toast.makeText(this, "get name failed: $it", Toast.LENGTH_LONG).show()
+//                    println("get name failed: $it")
+//                })
+//    }
+//
+//    private fun getFriendName(friendId: String) { // idを引数に、nameをゲットする関数。ユーザー情報のGET/POSTメソッドはどっかに分離したほうがわかりやすそう。
+//        userProfileService.getUserById(friendId)
+//                .subscribeOn(Schedulers.io())
+//                .observeOn(AndroidSchedulers.mainThread())
+//                .subscribe({
+//                    Toast.makeText(this, "get name succeeded", Toast.LENGTH_SHORT).show()
+//                    println("get name succeeded: $it")
+//                    adapter?.addAll(it)
+//                }, {
+//                    Toast.makeText(this, "get name failed: $it", Toast.LENGTH_LONG).show()
+//                    println("get name failed: $it")
+//                })
+//    }
+//
+//    private fun goToAddFriend(userId: String) {
+//        val intent = Intent(this, AddFriendActivity::class.java)
+//        intent.putExtra("userId", userId)
+//        startActivity(intent)
+//    }
+//
+//    private fun goToTalk(roomId: Int) {
+//        val intent = Intent(this, TalkActivity::class.java)
+//        intent.putExtra("userId", userId)
+//        intent.putExtra("roomId", roomId.toString())
+//        startActivity(intent)
+//    }
+//}

--- a/app/src/main/java/intern/line/tokyoaclient/TalkListFragment.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/TalkListFragment.kt
@@ -1,0 +1,29 @@
+package intern.line.tokyoaclient
+
+
+import android.os.Bundle
+import android.support.v4.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+
+
+// TODO: Rename parameter arguments, choose names that match
+// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+private const val ARG_PARAM1 = "param1"
+private const val ARG_PARAM2 = "param2"
+
+/**
+ * A simple [Fragment] subclass.
+ *
+ */
+class TalkListFragment : Fragment() {
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
+                              savedInstanceState: Bundle?): View? {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_talk_list, container, false)
+    }
+
+
+}

--- a/app/src/main/res/layout/activity_tab_layout.xml
+++ b/app/src/main/res/layout/activity_tab_layout.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <android.support.design.widget.TabLayout
+        android:id="@+id/tabs_main"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:tabMode="fixed" />
+
+    <android.support.v4.view.ViewPager
+        android:id="@+id/viewpager_main"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@+id/tabs_main"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_talk_list.xml
+++ b/app/src/main/res/layout/activity_talk_list.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</ConstraintLayout>

--- a/app/src/main/res/layout/fragment_friend_list.xml
+++ b/app/src/main/res/layout/fragment_friend_list.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".FriendListFragment">
+
+    <!-- TODO: Update blank fragment layout -->
+    <android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:id="@+id/constraintLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/friendListTextView"
+            android:layout_width="381dp"
+            android:layout_height="32dp"
+            android:layout_marginBottom="3dp"
+            android:layout_marginEnd="2dp"
+            android:layout_marginLeft="1dp"
+            android:layout_marginRight="2dp"
+            android:layout_marginStart="1dp"
+            android:layout_marginTop="1dp"
+            android:text="Friend List"
+            android:textSize="24sp"
+            app:layout_constraintBottom_toTopOf="@+id/friendList"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/addFriendButton"
+            tools:text="Friend List" />
+
+        <TextView
+            android:id="@+id/ownNameText"
+            android:layout_width="321dp"
+            android:layout_height="37dp"
+            android:layout_marginBottom="9dp"
+            android:layout_marginEnd="5dp"
+            android:layout_marginLeft="7dp"
+            android:layout_marginRight="5dp"
+            android:layout_marginStart="7dp"
+            android:layout_marginTop="5dp"
+            android:gravity="center_vertical"
+            android:text="Hello"
+            android:textSize="30sp"
+            app:layout_constraintBottom_toTopOf="@+id/friendListTextView"
+            app:layout_constraintEnd_toStartOf="@+id/addFriendButton"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ListView
+            android:id="@+id/friendList"
+            android:layout_width="0dp"
+            android:layout_height="480dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/friendListTextView"
+            app:layout_constraintVertical_bias="1.0" />
+
+        <Button
+            android:id="@+id/addFriendButton"
+            style="@style/Widget.AppCompat.Button.Small"
+            android:layout_width="50dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="1dp"
+            android:layout_marginRight="1dp"
+            android:gravity="center_vertical|center_horizontal"
+            android:text="+"
+            android:textSize="24sp"
+            app:layout_constraintBottom_toTopOf="@+id/ownNameText"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toEndOf="@+id/friendListTextView"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.019" />
+    </android.support.constraint.ConstraintLayout>
+
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".SettingFragment">
+
+    <!-- TODO: Update blank fragment layout -->
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="@string/hello_blank_fragment" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_talk_list.xml
+++ b/app/src/main/res/layout/fragment_talk_list.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".TalkListFragment">
+
+    <!-- TODO: Update blank fragment layout -->
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="@string/hello_blank_fragment" />
+
+</FrameLayout>

--- a/app/src/main/res/menu/menu_tab_layout_test.xml
+++ b/app/src/main/res/menu/menu_tab_layout_test.xml
@@ -1,0 +1,9 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context="intern.line.tokyoaclient.TabLayoutTestActivity">
+    <item
+        android:id="@+id/action_settings"
+        android:orderInCategory="100"
+        android:showAsAction="never"
+        android:title="@string/action_settings" />
+</menu>

--- a/app/src/main/res/values-w820dp/dimens.xml
+++ b/app/src/main/res/values-w820dp/dimens.xml
@@ -1,0 +1,6 @@
+<resources>
+    <!-- Example customization of dimensions originally defined in res/values/dimens.xml
+         (such as screen margins) for screens with more than 820dp of available width. This
+         would include 7" and 10" devices in landscape (~960dp and ~1280dp respectively). -->
+    <dimen name="activity_horizontal_margin">64dp</dimen>
+</resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<resources>
+    <!-- Default screen margins, per the Android Design guidelines. -->
+    <dimen name="activity_horizontal_margin">16dp</dimen>
+    <dimen name="activity_vertical_margin">16dp</dimen>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,13 @@
 <resources>
     <string name="app_name">TokyoAClient</string>
     <string name="result">Hello, %s!</string>
+
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="title_activity_tab_layout_test">TabLayoutTestActivity</string>
+    <string name="tab_text_1">Tab 1</string>
+    <string name="tab_text_2">Tab 2</string>
+    <string name="tab_text_3">Tab 3</string>
+    <string name="action_settings">Settings</string>
+    <string name="section_format">Hello World from section: %1$d</string>
 </resources>


### PR DESCRIPTION
ログイン後の画面をタブレイアウトに変更し、
とりあえず既存の画面(フレンドリスト→フレンド追加など)がタブレイアウトで動くようにしました

タブレイアウト及びフラグメントがなかなか仕様が複雑で時間を食ったので、覚え書きを残しておきます

### タブレイアウトを実現する流れ
- タブレイアウト内に表示する各ページ(フラグメント)を用意 `XXXFragment.kt`
- タブレイアウトを格納するアクティビティを用意 `TabLayoutActivity.kt`
(タブ部分のtab layout要素と実際にページを表示する部分のview pager要素を配置)
- pager adapterを継承したクラスを作成( `MyPagerAdapter.kt`)、フラグメントと接続
- `TabLayoutActivity.kt`内でview pager要素にカスタムしたアダプタをセットしフラグメントを読み込む

### ActivityとFragmentの違いで詰まった部分
#### IntentのputExtraで変数を渡せない
ActivityからFragmentに変数を渡すときには、
Fragmentを生成する(`MyPagerAdapter.kt`)ときにバンドルに引数を設定しなければならない
実際の流れでいうと

アダプタクラスの引数にuser idを設定
```
class MyPagerAdapter(fm: FragmentManager, uid: String) 
```
タブレイアウトの親Activity上でputExtraを受け取りアダプタに渡す
```
val userId = intent.getStringExtra("userId")
val fragmentAdapter = MyPagerAdapter(supportFragmentManager, userId)
```
その引数をアダプタクラス内でバンドルに格納しフラグメントにセットする
```
val bundle = Bundle()
bundle.putString("userId",userId)
val frg = FriendListFragment()
frg.setArguments(bundle)
```
フラグメント内でバンドルから読み込む
```
userId = arguments!!.getString("userId")
```

#### ToastやIntentのcontext引数にthisを指定できない
fragmentはactivityと違い自身にcontextを持たないのでthisは使えない
thisの代わりにcontext(`getContext()`の省略)に置換し、activityのcontextを引っ張ってくることで解決する

#### findViewByIdを使えない
フラグメント内では使えないので、要素を取得するには
`view = inflater.inflate(R.layout.fragment_friend_list, container, false)`
のようにレイアウトを変数に読み込んで(原理はよくわかってない)
`view.findViewById...`
とすると取得できる