### PR TITLE
talk room action

### DIFF
--- a/app/src/main/java/intern/line/tokyoaclient/FriendListFragment.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/FriendListFragment.kt
@@ -12,10 +12,12 @@ import android.widget.ListView
 import android.widget.TextView
 import android.widget.Toast
 import intern.line.tokyoaclient.HttpConnection.friendService
+import intern.line.tokyoaclient.HttpConnection.model.UserProfile
 import intern.line.tokyoaclient.HttpConnection.userProfileService
 import rx.android.schedulers.AndroidSchedulers
 import rx.schedulers.Schedulers
 import java.util.*
+import kotlin.collections.ArrayList
 
 
 // TODO: Rename parameter arguments, choose names that match
@@ -24,6 +26,7 @@ import java.util.*
 
 private lateinit var friendList: ListView
 private lateinit var addFriendButton: Button
+private lateinit var data: ArrayList<UserProfile>
 private var adapter: UserListAdapter? = null
 
 private lateinit var userId: String
@@ -40,7 +43,8 @@ class FriendListFragment : Fragment() {
         addFriendButton = v.findViewById(R.id.addFriendButton) as Button
         friendList = v.findViewById(R.id.friendList) as ListView
 
-        adapter = UserListAdapter(context!!, ArrayList())
+        data = ArrayList()
+        adapter = UserListAdapter(context!!, data)
         friendList.setAdapter(adapter)
 
         getOwnName(userId)
@@ -54,7 +58,7 @@ class FriendListFragment : Fragment() {
             val num1: Int = Math.abs(UUID.nameUUIDFromBytes(userId.toByteArray()).hashCode())
             val num2: Int = Math.abs(UUID.nameUUIDFromBytes(friendId.toByteArray()).hashCode())
             val roomId: Int = num1 + num2
-            goToTalk(roomId)
+            goToTalk(roomId, view.findViewById<TextView>(R.id.nameTextView).text.toString())
         }
         return v
     }
@@ -98,6 +102,7 @@ class FriendListFragment : Fragment() {
                     Toast.makeText(context, "get name succeeded", Toast.LENGTH_SHORT).show()
                     println("get name succeeded: $it")
                     adapter?.addAll(it)
+                    Collections.sort(data, NameComparator())
                 }, {
                     Toast.makeText(context, "get name failed: $it", Toast.LENGTH_LONG).show()
                     println("get name failed: $it")
@@ -110,8 +115,9 @@ class FriendListFragment : Fragment() {
         startActivity(intent)
     }
 
-    private fun goToTalk(roomId: Int) {
+    private fun goToTalk(roomId: Int, name: String) {
         val intent = Intent(context, TalkActivity::class.java)
+        intent.putExtra("roomName", name)
         intent.putExtra("userId", userId)
         intent.putExtra("roomId", roomId.toString())
         startActivity(intent)

--- a/app/src/main/java/intern/line/tokyoaclient/HttpConnection/model/entities.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/HttpConnection/model/entities.kt
@@ -46,3 +46,14 @@ data class RoomMember(
         var createdAt: Timestamp = Timestamp(0L),
         var updatedAt: Timestamp = Timestamp(0L)
 )
+
+data class TalkWithImageUrl(
+        var talkId: Long = -1,
+        var senderName: String = "sender",
+        var roomId: Long = -1,
+        var text: String = "Hello, world!",
+        var numRead: Long = 0,
+        var pathToFile: String,
+        var createdAt: Timestamp = Timestamp(0L),
+        var updatedAt: Timestamp = Timestamp(0L)
+)

--- a/app/src/main/java/intern/line/tokyoaclient/TalkActivity.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/TalkActivity.kt
@@ -1,19 +1,25 @@
 package intern.line.tokyoaclient
 
-import android.content.Intent
+import android.content.Context
 import android.os.Bundle
+import android.support.constraint.ConstraintLayout
 import android.support.v7.app.AppCompatActivity
+import android.util.EventLog
 import android.view.KeyEvent
-import android.widget.ArrayAdapter
-import android.widget.Button
-import android.widget.ListView
+import android.view.MotionEvent
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+import android.widget.*
 import kotlinx.android.synthetic.main.activity_talk_page.*
 import rx.android.schedulers.AndroidSchedulers
 import rx.schedulers.Schedulers
-import android.widget.Toast
+import intern.line.tokyoaclient.HttpConnection.imageService
 import intern.line.tokyoaclient.HttpConnection.model.Talk
+import intern.line.tokyoaclient.HttpConnection.model.TalkWithImageUrl
 import intern.line.tokyoaclient.HttpConnection.talkService
+import intern.line.tokyoaclient.HttpConnection.userProfileService
 import java.util.*
+import kotlin.collections.ArrayList
 import kotlin.concurrent.schedule
 
 
@@ -23,22 +29,30 @@ class TalkActivity : AppCompatActivity() {
     private var roomId: Long = -1
     private var sinceTalkId: Long = -1
     private lateinit var talkList: ListView
-    private lateinit var adapter: ArrayAdapter<String>
+    private var adapter: TalkAdapter? = null
     private lateinit var timer: TimerTask
+    private lateinit var data: ArrayList<TalkWithImageUrl>
+
+    // キーボード表示を制御するためのオブジェクト
+    private lateinit var inputMethodManager: InputMethodManager
+    // 背景のレイアウト
+    private lateinit var mainLayout: ConstraintLayout
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_talk_page)
 
         talkList = (findViewById(R.id.talkList) as ListView)
-        var data: ArrayList<String> = ArrayList<String>()
-        adapter = ArrayAdapter<String>(this, android.R.layout.simple_list_item_1, data)
+        data = ArrayList()
+        adapter = TalkAdapter(this, data)
         talkList.setAdapter(adapter)
 
+        (findViewById(R.id.roomName) as TextView).text = intent.getStringExtra("roomName")
         userId = intent.getStringExtra("userId")
         roomId = intent.getStringExtra("roomId").toLong()
 
-        getMessage()
+        inputMethodManager = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        mainLayout = findViewById(R.id.main_layout) as ConstraintLayout
 
         //ボタンをゲットしておく
         val sendButton = findViewById(R.id.sendButton) as Button
@@ -46,12 +60,19 @@ class TalkActivity : AppCompatActivity() {
         //それぞれのボタンが押されたときにメソッドを呼び出す
         sendButton.setOnClickListener {
             sendMessage()
-            getAllMessages()
+        }
+
+        talkList.setOnItemClickListener { adapterView, view, position, id ->
+            focusOnBackground()
         }
 
         timer = Timer().schedule(0, 1000, { getMessage() })
     }
 
+    override fun onTouchEvent(event: MotionEvent?): Boolean {
+        focusOnBackground()
+        return super.onTouchEvent(event)
+    }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
         if (keyCode == KeyEvent.KEYCODE_BACK) {
@@ -59,6 +80,13 @@ class TalkActivity : AppCompatActivity() {
             timer.cancel()
         }
         return super.onKeyDown(keyCode, event)
+    }
+
+    private fun focusOnBackground() {
+        // キーボードを隠す
+        inputMethodManager.hideSoftInputFromWindow(mainLayout.windowToken, InputMethodManager.HIDE_NOT_ALWAYS)
+        // 背景にフォーカスを移す
+        mainLayout.requestFocus()
     }
 
     private fun sendMessage() {
@@ -71,14 +99,14 @@ class TalkActivity : AppCompatActivity() {
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe({
-                        Toast.makeText(this, "send talk succeeded", Toast.LENGTH_SHORT).show()
+                        // Toast.makeText(this, "send talk succeeded", Toast.LENGTH_SHORT).show()
                         println("send talk succeeded: $input")
-
                         getMessage()
                         inputText.editableText.clear() // 入力内容をリセットする
-                        talkList.setSelection(adapter.count)
+                        adapter?.notifyDataSetChanged()
+                        // talkList.setSelection(adapter!!.count)
                     }, {
-                        Toast.makeText(this, "send talk failed: $it", Toast.LENGTH_SHORT).show()
+                        // Toast.makeText(this, "send talk failed: $it", Toast.LENGTH_SHORT).show()
                         println("send talk failed: $it")
                     })
         }
@@ -89,6 +117,7 @@ class TalkActivity : AppCompatActivity() {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
+                    sinceTalkId = it.last().talkId
                     println(it.toString())
                 }, {
 
@@ -104,24 +133,49 @@ class TalkActivity : AppCompatActivity() {
                     println("get talk succeeded: $it")
 
                     if (!it.isEmpty()) {
-                        println("it[0].talkId: ${it[0].talkId}")
+                        // println("it[0].talkId: ${it[0].talkId}")
                         sinceTalkId = it.last().talkId
-                        adapter.addAll(it.map { talk -> talk.text })
+                        // adapter.addAll(it.map { talk -> talk.text })
+                        for(t in it) {
+                            getSendersName(t)
+                        }
                     }
 
                     println("sinceTalkId: $sinceTalkId")
-                    talkList.setSelection(adapter.count)
+                    adapter?.notifyDataSetChanged()
                 }, {
                     Toast.makeText(this, "get talk failed: $it", Toast.LENGTH_SHORT).show()
                     println("get talk failed: $it")
                 })
     }
 
-    /* no use for now on
-    private fun intent(uid:String) {
-        var intent= Intent(this, MainPageActivity::class.java)
-        intent.putExtra("userId", uid)
-        startActivity(intent)
+    private fun getSendersName(talk: Talk) {
+        userProfileService.getUserById(talk.senderId)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                    //Toast.makeText(this, "get talk succeeded", Toast.LENGTH_SHORT).show()
+                    println("get name succeeded: $it")
+                    getImageUrl(talk, it.name)
+                }, {
+                    // Toast.makeText(this, "get name failed: $it", Toast.LENGTH_SHORT).show()
+                    println("get name failed: $it")
+                })
     }
-    */
+
+    private fun getImageUrl(talk: Talk, name: String) {
+        imageService.getImageUrlById(talk.senderId)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                    //Toast.makeText(this, "get image url succeeded", Toast.LENGTH_SHORT).show()
+                    println("get image url succeeded: $it")
+                    adapter?.add(TalkWithImageUrl(talk.talkId, name, talk.roomId, talk.text, talk.numRead, it.pathToFile, talk.createdAt, talk.updatedAt))
+                    Collections.sort(data, TimeComparator())
+                    talkList.setSelection(adapter!!.count)
+                }, {
+                    // Toast.makeText(this, "get image url failed: $it", Toast.LENGTH_SHORT).show()
+                    println("get image url failed: $it")
+                })
+    }
 }

--- a/app/src/main/java/intern/line/tokyoaclient/TalkAdapter.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/TalkAdapter.kt
@@ -1,0 +1,49 @@
+package intern.line.tokyoaclient
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.ImageView
+import android.widget.TextView
+import com.bumptech.glide.Glide
+import intern.line.tokyoaclient.HttpConnection.model.TalkWithImageUrl
+
+
+class TalkAdapter(context: Context, users: List<TalkWithImageUrl>) : ArrayAdapter<TalkWithImageUrl>(context, 0, users) {
+    private val layoutInflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
+
+    override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View {
+        var view = convertView
+        var holder: TalkViewHolder
+
+        if (view == null) {
+            view = layoutInflater.inflate(R.layout.talk_list_item, parent, false)
+            holder = TalkViewHolder(
+                    (view.findViewById(R.id.nameTextView) as TextView),
+                    (view.findViewById(R.id.textTextView) as TextView),
+                    (view.findViewById(R.id.timeTextView) as TextView),
+                    (view.findViewById(R.id.icon) as ImageView)
+            )
+            view.tag = holder
+        } else {
+            holder = view.tag as TalkViewHolder
+        }
+
+        val user = getItem(position) as TalkWithImageUrl
+        holder.nameTextView.text = user.senderName
+        holder.textTextView.text = user.text
+        holder.timeTextView.text = user.createdAt.toString().substring(11, 16) // yyyy-mm-dd hh:mm:ss
+        Glide.with(context).load("http://ec2-52-197-250-179.ap-northeast-1.compute.amazonaws.com/image/url/" + user.pathToFile).into(holder.iconImageView)
+        return view!!
+    }
+}
+
+data class TalkViewHolder(val nameTextView: TextView, val textTextView: TextView, val timeTextView: TextView, val iconImageView: ImageView)
+
+class TimeComparator(): Comparator<TalkWithImageUrl> {
+    override fun compare(lt: TalkWithImageUrl, rt: TalkWithImageUrl): Int {
+        return lt.createdAt.compareTo(rt.createdAt)
+    }
+}

--- a/app/src/main/java/intern/line/tokyoaclient/UserListAdapter.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/UserListAdapter.kt
@@ -35,3 +35,9 @@ class UserListAdapter(context: Context, users: List<UserProfile>) : ArrayAdapter
 }
 
 data class ViewHolder(val nameTextView: TextView, val idTextView: TextView)
+
+class NameComparator(): Comparator<UserProfile> {
+    override fun compare(lt: UserProfile, rt: UserProfile): Int {
+        return lt.name.compareTo(rt.name)
+    }
+}

--- a/app/src/main/res/layout/activity_talk_page.xml
+++ b/app/src/main/res/layout/activity_talk_page.xml
@@ -2,14 +2,27 @@
 <android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:id="@+id/main_layout"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:focusableInTouchMode="true">
+
+    <TextView
+        android:id="@+id/roomName"
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:hint="名前"
+        android:background="@color/colorPrimaryDark"
+        android:textSize="30sp"
+        android:gravity="center"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <ListView
         android:id="@+id/talkList"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:layout_marginTop="50dp"
         android:layout_marginBottom="50dp"
-        app:layout_constraintBottom_toTopOf="@+id/inputText" />
+        app:layout_constraintBottom_toBottomOf="parent" />
 
     <EditText
         android:id="@+id/inputText"

--- a/app/src/main/res/layout/talk_list_item.xml
+++ b/app/src/main/res/layout/talk_list_item.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <ImageView
+        android:id="@+id/icon"
+        android:layout_width="60dp"
+        android:layout_height="60dp" />
+
+    <TextView
+        android:id="@+id/nameTextView"
+        android:layout_height="20dp"
+        android:layout_width="match_parent"
+        android:gravity="center_vertical"
+        android:layout_marginStart="60dp"
+        android:layout_marginLeft="60dp"
+        android:text="Friend_name"
+        android:textSize="15sp"
+        app:layout_constraintStart_toEndOf="@+id/icon"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/textTextView"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:gravity="center_vertical"
+        android:layout_marginStart="60dp"
+        android:layout_marginLeft="60dp"
+        android:layout_marginEnd="60dp"
+        android:layout_marginRight="60dp"
+        android:text="hogehogehogehogehogehogehogehogehogehogehogehoge"
+        android:textSize="20sp"
+        app:layout_constraintTop_toBottomOf="@+id/nameTextView"
+        app:layout_constraintStart_toEndOf="@+id/icon" />
+
+    <TextView
+        android:id="@+id/timeTextView"
+        android:layout_height="wrap_content"
+        android:layout_width="50dp"
+        android:gravity="center_vertical"
+        android:text="time"
+        android:textSize="15sp"
+        app:layout_constraintBottom_toBottomOf="@+id/textTextView"
+        app:layout_constraintStart_toEndOf="@+id/textTextView" />
+
+</android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
今までトークしか表示されなかったトークルームに
アイコン・ユーザ名・トーク・時間を表示できるようにしました．

`Talk`クラスには`userId`しか含まれておらず，そこから

- ユーザ名の検索と
- アイコン画像のURLの検索

のために再度DBに問い合わせていますが，そのときfor文で全並列で走らせているので，Adapterに入れるタイミングがトークの時系列順になりません．なので，現状は間に合せのためにAdapterに入れるたびにソートするという超絶コストのかかる仮の方法で実装しています．今後時間があれば．この点は賢く実装しなおしたいところですね．

ついでに，これと同じ方法でフレンドリストで表示されるフレンドの順もソートして表示するようにしました． #30

下の画像では，時刻がエミュレータの設定のせいかイギリス時間になっていますね笑

![screenshot 2018-09-12 03 05 12](https://user-images.githubusercontent.com/22876812/45378973-d489ec80-b639-11e8-90e3-ac6bd3769928.png)
