### PR TITLE
fix bug

### DIFF
--- a/app/src/debug/res/layout/activity_add_friend.xml
+++ b/app/src/debug/res/layout/activity_add_friend.xml
@@ -38,10 +38,24 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/searchNameText" />
 
+    <TextView
+        android:id="@+id/alreadyFriendTextView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="21dp"
+        android:layout_marginTop="10dp"
+        android:gravity="center"
+        android:background="@color/colorPrimaryDark"
+        android:text="フレンド"
+        android:textSize="12sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/searchFriendButton" />
+
     <ListView
-        android:id="@+id/searchFriendResultList"
+        android:id="@+id/alreadyFriendList"
         android:layout_width="368dp"
-        android:layout_height="338dp"
+        android:layout_height="150dp"
         android:layout_marginEnd="8dp"
         android:layout_marginLeft="8dp"
         android:layout_marginRight="8dp"
@@ -49,7 +63,34 @@
         android:layout_marginTop="8dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/searchFriendButton" />
+        app:layout_constraintTop_toBottomOf="@+id/alreadyFriendTextView" />
+
+    <TextView
+        android:id="@+id/newFriendTextView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="21dp"
+        android:layout_marginTop="0dp"
+        android:gravity="center"
+        android:background="@color/colorPrimaryDark"
+        android:text="新しいフレンド"
+        android:textSize="12sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/alreadyFriendList" />
+
+    <ListView
+        android:id="@+id/searchFriendResultList"
+        android:layout_width="368dp"
+        android:layout_height="150dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginRight="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="0dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/newFriendTextView" />
 
     <TextView
         android:id="@+id/AddFriendTextView"


### PR DESCRIPTION
#23 #38 のバグを解消しました．
部分検索で見つかったユーザを
- すでに登録済みのフレンドと
- そうではないフレンド

に振り分ける処理を入れました．
前者をタップするとトーク画面に遷移，後者をタップすると新規フレンドとしてaddするようにしました．
現状，すでに登録済みのフレンドはdbに問い合わせて確保していますが，
ローカルdbが使えるようになれば（なるのか？）そっちのほうが簡単で良いですね．