### PR TITLE
Group And LocalDB

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -25,7 +25,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
         <activity android:name=".EditNameActivity" />
         <activity android:name=".EditIconActivity" />
         <activity android:name=".CreateGroupActivity" />
+        <activity android:name=".ConfigureGroupActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
         <activity android:name=".localDBDebugActivity" />
         <activity android:name=".EditNameActivity" />
         <activity android:name=".EditIconActivity" />
+        <activity android:name=".CreateGroupActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/intern/line/tokyoaclient/Adapter/MyPagerAdapter.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/Adapter/MyPagerAdapter.kt
@@ -1,9 +1,12 @@
-package intern.line.tokyoaclient
+package intern.line.tokyoaclient.Adapter
 
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.support.v4.app.FragmentManager
 import android.support.v4.app.FragmentPagerAdapter
+import intern.line.tokyoaclient.Fragment.FriendListFragment
+import intern.line.tokyoaclient.Fragment.SettingFragment
+import intern.line.tokyoaclient.Fragment.TalkListFragment
 
 class MyPagerAdapter(fm: FragmentManager, uid: String) : FragmentPagerAdapter(fm) {
     val bundle = Bundle()

--- a/app/src/main/java/intern/line/tokyoaclient/Adapter/MyPagerAdapter.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/Adapter/MyPagerAdapter.kt
@@ -41,9 +41,7 @@ class MyPagerAdapter(fm: FragmentManager, uid: String) : FragmentPagerAdapter(fm
         return when (position) {
             0 -> "Friend List"
             1 -> "Talk List"
-            else -> {
-                return "Settings"
-            }
+            else -> "Settings"
         }
     }
 }

--- a/app/src/main/java/intern/line/tokyoaclient/Adapter/RoomAdapter.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/Adapter/RoomAdapter.kt
@@ -10,6 +10,7 @@ import android.widget.TextView
 import com.bumptech.glide.Glide
 import intern.line.tokyoaclient.HttpConnection.model.RoomWithImageUrlAndLatestTalk
 import intern.line.tokyoaclient.R
+import java.sql.Timestamp
 
 
 class RoomAdapterWithImage(context: Context, rooms: List<RoomWithImageUrlAndLatestTalk>) : ArrayAdapter<RoomWithImageUrlAndLatestTalk>(context, 0, rooms) {
@@ -53,6 +54,15 @@ data class RoomViewHolder(
 
 class RoomComparator(): Comparator<RoomWithImageUrlAndLatestTalk> {
     override fun compare(lt: RoomWithImageUrlAndLatestTalk, rt: RoomWithImageUrlAndLatestTalk): Int {
-        return rt.latestTalkTime.compareTo(lt.latestTalkTime)
+        when {
+            rt.latestTalkTime.equals(Timestamp(0L)) && lt.latestTalkTime.equals(Timestamp(0L))
+                -> return rt.createdAt.compareTo(lt.createdAt)
+            rt.latestTalkTime.equals(Timestamp(0L))
+                -> return rt.createdAt.compareTo(lt.latestTalkTime)
+            lt.latestTalkTime.equals(Timestamp(0L))
+                -> return rt.latestTalkTime.compareTo(lt.createdAt)
+            else
+                -> return rt.latestTalkTime.compareTo(lt.latestTalkTime)
+        }
     }
 }

--- a/app/src/main/java/intern/line/tokyoaclient/Adapter/RoomAdapter.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/Adapter/RoomAdapter.kt
@@ -1,4 +1,4 @@
-package intern.line.tokyoaclient
+package intern.line.tokyoaclient.Adapter
 
 import android.content.Context
 import android.view.LayoutInflater
@@ -9,7 +9,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import com.bumptech.glide.Glide
 import intern.line.tokyoaclient.HttpConnection.model.RoomWithImageUrlAndLatestTalk
-import intern.line.tokyoaclient.HttpConnection.model.UserProfileWithImageUrl
+import intern.line.tokyoaclient.R
 
 
 class RoomAdapterWithImage(context: Context, rooms: List<RoomWithImageUrlAndLatestTalk>) : ArrayAdapter<RoomWithImageUrlAndLatestTalk>(context, 0, rooms) {

--- a/app/src/main/java/intern/line/tokyoaclient/Adapter/TalkAdapter.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/Adapter/TalkAdapter.kt
@@ -1,4 +1,4 @@
-package intern.line.tokyoaclient
+package intern.line.tokyoaclient.Adapter
 
 import android.content.Context
 import android.view.LayoutInflater
@@ -9,6 +9,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import com.bumptech.glide.Glide
 import intern.line.tokyoaclient.HttpConnection.model.TalkWithImageUrl
+import intern.line.tokyoaclient.R
 
 
 class TalkAdapter(context: Context, users: List<TalkWithImageUrl>) : ArrayAdapter<TalkWithImageUrl>(context, 0, users) {

--- a/app/src/main/java/intern/line/tokyoaclient/Adapter/TestDataAdapter.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/Adapter/TestDataAdapter.kt
@@ -1,4 +1,4 @@
-package intern.line.tokyoaclient
+package intern.line.tokyoaclient.Adapter
 
 import android.content.Context
 import android.view.LayoutInflater
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import android.widget.ArrayAdapter
 import android.widget.TextView
 import intern.line.tokyoaclient.HttpConnection.model.Talk
+import intern.line.tokyoaclient.R
 
 class TestDataAdapter(context: Context, data: List<Talk>) : ArrayAdapter<Talk>(context, 0, data) {
     private val layoutInflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater

--- a/app/src/main/java/intern/line/tokyoaclient/Adapter/UserListAdapter.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/Adapter/UserListAdapter.kt
@@ -1,7 +1,6 @@
-package intern.line.tokyoaclient
+package intern.line.tokyoaclient.Adapter
 
 import android.content.Context
-import android.media.Image
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -11,6 +10,7 @@ import android.widget.TextView
 import com.bumptech.glide.Glide
 import intern.line.tokyoaclient.HttpConnection.model.UserProfile
 import intern.line.tokyoaclient.HttpConnection.model.UserProfileWithImageUrl
+import intern.line.tokyoaclient.R
 
 
 class UserListAdapter(context: Context, users: List<UserProfile>) : ArrayAdapter<UserProfile>(context, 0, users) {
@@ -77,3 +77,31 @@ class NameComparator(): Comparator<UserProfileWithImageUrl> {
     }
 }
 
+class UserListAdapterWithImageSelection(context: Context, usersWithImageUrl: List<UserProfileWithImageUrl>) : ArrayAdapter<UserProfileWithImageUrl>(context, 0, usersWithImageUrl) {
+    private val layoutInflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
+
+    override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View {
+        var view = convertView
+        var holder: ViewHolderWithImageSelection
+
+        if (view == null) {
+            view = layoutInflater.inflate(R.layout.multiple_choice_friend_list_item, parent, false)
+            holder = ViewHolderWithImageSelection(
+                    (view.findViewById(R.id.nameTextView) as TextView),
+                    (view.findViewById(R.id.icon) as ImageView),
+                    "default.jpg"
+            )
+            view.tag = holder
+        } else {
+            holder = view.tag as ViewHolderWithImageSelection
+        }
+
+        val user = getItem(position) as UserProfileWithImageUrl
+        holder.nameTextView.text = user.name
+        holder.pathToFile = user.pathToFile
+        Glide.with(context).load("http://ec2-52-197-250-179.ap-northeast-1.compute.amazonaws.com/image/url/" + user.pathToFile).into(holder.iconImageView)
+        return view!!
+    }
+}
+
+data class ViewHolderWithImageSelection(val nameTextView: TextView, val iconImageView: ImageView, var pathToFile: String)

--- a/app/src/main/java/intern/line/tokyoaclient/AddFriendActivity.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/AddFriendActivity.kt
@@ -14,6 +14,8 @@ import rx.android.schedulers.AndroidSchedulers
 import rx.schedulers.Schedulers
 import android.widget.Toast
 import android.widget.TextView
+import intern.line.tokyoaclient.Adapter.NameComparator
+import intern.line.tokyoaclient.Adapter.UserListAdapterWithImage
 import intern.line.tokyoaclient.HttpConnection.friendService
 import intern.line.tokyoaclient.HttpConnection.imageService
 import intern.line.tokyoaclient.HttpConnection.model.UserProfileWithImageUrl
@@ -81,7 +83,7 @@ class AddFriendActivity : AppCompatActivity() {
         searchFriendButton.setOnClickListener {
             searchFriend()
         }
-        alreadyFriendList.setOnItemClickListener { adapterView, view, position, id ->
+        alreadyFriendList.setOnItemClickListener { _, view, _, _ ->
             val friendId = view.findViewById<TextView>(R.id.idTextView).text.toString()
             val friendName = view.findViewById<TextView>(R.id.nameTextView).text.toString()
             val num1: Int = Math.abs(UUID.nameUUIDFromBytes(userId.toByteArray()).hashCode())
@@ -89,7 +91,7 @@ class AddFriendActivity : AppCompatActivity() {
             val roomId: Int = num1 + num2
             goToTalk(roomId, friendName)
         }
-        searchFriendResultList.setOnItemClickListener { adapterView, view, position, id ->
+        searchFriendResultList.setOnItemClickListener { _, view, position, _ ->
             val friendId = view.findViewById<TextView>(R.id.idTextView).text.toString()
             val friendName = view.findViewById<TextView>(R.id.nameTextView).text.toString()
             val pathToFile = newFriendData[position].pathToFile

--- a/app/src/main/java/intern/line/tokyoaclient/AddFriendActivity.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/AddFriendActivity.kt
@@ -1,7 +1,6 @@
 package intern.line.tokyoaclient
 
 import android.app.Activity
-import android.content.ContentValues
 import android.content.Intent
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteException
@@ -19,7 +18,12 @@ import intern.line.tokyoaclient.Adapter.UserListAdapterWithImage
 import intern.line.tokyoaclient.HttpConnection.friendService
 import intern.line.tokyoaclient.HttpConnection.imageService
 import intern.line.tokyoaclient.HttpConnection.model.UserProfileWithImageUrl
+import intern.line.tokyoaclient.HttpConnection.roomService
 import intern.line.tokyoaclient.LocalDataBase.FriendDBHelper
+import intern.line.tokyoaclient.LocalDataBase.FriendLocalDBService
+import intern.line.tokyoaclient.LocalDataBase.RoomDBHelper
+import intern.line.tokyoaclient.LocalDataBase.RoomLocalDBService
+import java.sql.Timestamp
 import java.util.*
 import kotlin.collections.ArrayList
 
@@ -37,7 +41,9 @@ class AddFriendActivity : AppCompatActivity() {
     private lateinit var friendIdData: ArrayList<String>
     // localDB
     private lateinit var fdb: SQLiteDatabase
-    private lateinit var helper: FriendDBHelper
+    private lateinit var friendHelper: FriendDBHelper
+    private lateinit var rdb: SQLiteDatabase
+    private lateinit var roomHelper: RoomDBHelper
 
     private lateinit var userId: String
 
@@ -62,23 +68,25 @@ class AddFriendActivity : AppCompatActivity() {
 
         if(USE_LOCAL_DB) {
             try {
-                helper = FriendDBHelper(this)
+                friendHelper = FriendDBHelper(this)
+                roomHelper = RoomDBHelper(this)
             } catch (e: SQLiteException) {
-                Toast.makeText(this, "helper error: ${e.toString()}", Toast.LENGTH_SHORT).show()
-                println("helper error: ${e.toString()}")
+                debugLog(this, "helper error: ${e.toString()}")
             }
 
-
             try {
-                fdb = helper.writableDatabase
+                fdb = friendHelper.writableDatabase
+                rdb = roomHelper.writableDatabase
                 Toast.makeText(this, "accessed to database", Toast.LENGTH_SHORT).show()
             } catch (e: SQLiteException) {
-                Toast.makeText(this, "writable error: ${e.toString()}", Toast.LENGTH_SHORT).show()
-                println("writable error: ${e.toString()}")
+                debugLog(this, "writable error: ${e.toString()}")
             }
         }
 
-        getFriend(userId)
+        if(USE_LOCAL_DB)
+            getFriendByLocalDB()
+        else
+            getFriend(userId)
 
         searchFriendButton.setOnClickListener {
             searchFriend()
@@ -88,16 +96,16 @@ class AddFriendActivity : AppCompatActivity() {
             val friendName = view.findViewById<TextView>(R.id.nameTextView).text.toString()
             val num1: Int = Math.abs(UUID.nameUUIDFromBytes(userId.toByteArray()).hashCode())
             val num2: Int = Math.abs(UUID.nameUUIDFromBytes(friendId.toByteArray()).hashCode())
-            val roomId: Int = num1 + num2
+            val roomId: String = (num1 + num2).toString()
+            addMemberToRoomAfterCreateRoom(userId, friendId, roomId)
             goToTalk(roomId, friendName)
         }
         searchFriendResultList.setOnItemClickListener { _, view, position, _ ->
             val friendId = view.findViewById<TextView>(R.id.idTextView).text.toString()
             val friendName = view.findViewById<TextView>(R.id.nameTextView).text.toString()
             val pathToFile = newFriendData[position].pathToFile
-            if(USE_LOCAL_DB) {
+            if(USE_LOCAL_DB)
                 addFriendToLocalDB(friendId, friendName, pathToFile) // 本来ならaddFriendの中でDBへの書き込みの成功が確認できてからlocalDBに追加するべき
-            }
             addFriend(userId, friendId, friendName)
         }
     }
@@ -110,17 +118,20 @@ class AddFriendActivity : AppCompatActivity() {
         return super.onKeyDown(keyCode, event)
     }
 
+    private fun getFriendByLocalDB() {
+        FriendLocalDBService().getAllFriend(fdb, this) {
+            friendIdData.add(it.getString(0))
+        }
+    }
+
     private fun getFriend(userId: String) {
         friendService.getFriendById(userId)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
                     friendIdData.addAll(it.map{friend ->  friend.friendId})
-                    // Toast.makeText(context, "get friend list succeeded", Toast.LENGTH_SHORT).show()
-                    // println("get friend list succeeded: $it")
                 }, {
-                    Toast.makeText(this, "get friend list failed: $it", Toast.LENGTH_LONG).show()
-                    println("get friend list failed: $it")
+                    debugLog(this, "get friend list failed: $it")
                 })
     }
 
@@ -133,31 +144,25 @@ class AddFriendActivity : AppCompatActivity() {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
                     for (u in it) {
-                        if(u.id in friendIdData) {
+                        if(u.id in friendIdData) { // すでにフレンドに登録されていればalreadyFriendDataに，登録されていなければnewFriendDataに追加
                             getFriendName(u.id, alreadyFriendData, alreadyFriendAdapter)
                         } else {
                             getFriendName(u.id, newFriendData, newFriendAdapter)
                         }
                     }
-                    // Toast.makeText(this, "search friend succeeded", Toast.LENGTH_SHORT).show()
-                    // println("search friend succeeded: $it")
                 }, {
-                    Toast.makeText(this, "search friend failed: $it", Toast.LENGTH_LONG).show()
-                    println("search friend failed: $it")
+                    debugLog(this, "search friend failed: $it")
                 })
     }
 
-    private fun getFriendName(friendId: String, data: ArrayList<UserProfileWithImageUrl>, adapter: UserListAdapterWithImage?) { // idを引数に、nameをゲットする関数。ユーザー情報のGET/POSTメソッドはどっかに分離したほうがわかりやすそう。
+    private fun getFriendName(friendId: String, data: ArrayList<UserProfileWithImageUrl>, adapter: UserListAdapterWithImage?) {
         userProfileService.getUserById(friendId)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
-                    // Toast.makeText(this, "get name succeeded", Toast.LENGTH_SHORT).show()
-                    // println("get name succeeded: $it")
                     getIcon(it.id, it.name, data, adapter)
                 }, {
-                    Toast.makeText(this, "get name failed: $it", Toast.LENGTH_LONG).show()
-                    println("get name failed: $it")
+                    debugLog(this, "get name failed: $it")
                 })
     }
 
@@ -166,8 +171,6 @@ class AddFriendActivity : AppCompatActivity() {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
-                    // Toast.makeText(this, "get image url succeeded: $it", Toast.LENGTH_SHORT).show()
-                    // println("get image url succeeded: $it")
                     if (it.pathToFile != "") {
                         adapter?.addAll(UserProfileWithImageUrl(idStr, nameStr, it.pathToFile))
                     } else {
@@ -175,11 +178,14 @@ class AddFriendActivity : AppCompatActivity() {
                     }
                     Collections.sort(data, NameComparator())
                 }, {
+                    debugLog(this, "get image url failed: $it")
                     adapter?.addAll(UserProfileWithImageUrl(idStr, nameStr, "default.jpg"))
                     Collections.sort(data, NameComparator())
-                    Toast.makeText(this, "get image url failed: $it", Toast.LENGTH_LONG).show()
-                    println("get image url failed: $it")
                 })
+    }
+
+    private fun addFriendToLocalDB(friendId: String, friendName: String, pathToFile: String) {
+        FriendLocalDBService().addFriend(friendId, friendName, pathToFile, fdb, this)
     }
 
     private fun addFriend(userId: String, friendId: String, friendName: String) {
@@ -188,52 +194,86 @@ class AddFriendActivity : AppCompatActivity() {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
                     Toast.makeText(this, "$friendName をフレンドに追加しました！", Toast.LENGTH_SHORT).show()
-                    println("add friend succeeded")
                     // フレンド画面へのintent
                     var intent = Intent()
                     intent.putExtra("newFriendId", friendId)
                     setResult(Activity.RESULT_OK, intent)
                     finish()
                 }, {
-                    Toast.makeText(this, "add friend failed: $it", Toast.LENGTH_LONG).show()
-                    println("add friend failed: $it")
+                    debugLog(this, "add friend failed: $it")
                 })
     }
 
-    private fun addFriendToLocalDB(friendId: String, friendName: String, pathToFile: String) {
-        var value: ContentValues
-        var res: Long
-        println("add friend to localDB")
-
-        // フレンドのidの追加
-        value = ContentValues().also {
-            it.put("friend_id", friendId)
-        }
-        res = fdb.insert("friends", null, value)
-        if(res < 0) {
-            // error
-            Toast.makeText(this, "error in INSERT", Toast.LENGTH_SHORT).show()
-            return
-        }
-
-        value = ContentValues().also {
-            it.put("id", friendId)
-            it.put("name", friendName)
-            it.put("path_to_file", pathToFile)
-        }
-        res = fdb.insert("friend_data", null, value)
-        if(res < 0) {
-            // error
-            Toast.makeText(this, "error in INSERT", Toast.LENGTH_SHORT).show()
-            return
-        }
+    private fun addMemberToRoomAfterCreateRoom(userId: String, friendId: String, roomId: String) {
+        // ルームの登録
+        roomService.addRoom(roomId, "default_room")
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                    for(u in arrayListOf(userId, friendId)) {
+                        addMemberToRoom(u, roomId)
+                    }
+                    if(USE_LOCAL_DB)
+                        addGroupToLocalDB(userId, friendId, roomId, "default_room")
+                }, {
+                    debugLog(this, "add room failed: $it")
+                })
     }
 
-    private fun goToTalk(roomId: Int, name: String) {
+    private fun addMemberToRoom(userId: String, roomId: String) {
+        // ルームメンバー（自分とフレンド）の登録
+        roomService.addRoomMember(roomId, userId)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                }, {
+                    Toast.makeText(this, "add room member failed: $it", Toast.LENGTH_LONG).show()
+                    println("add room member failed: $it")
+                })
+    }
+
+    private fun addGroupToLocalDB(userId: String, friendId: String, roomId: String, roomName: String) {
+        // ルームの情報を取得してから，localDBに保存
+        roomService.getRoomByRoomId(roomId)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                    val room = it
+                    RoomLocalDBService().getRoomById(roomId, rdb, this) {
+                        if(it.count == 0) { // ルームがまだ存在していなければ
+                            // ルームのlocalDBへの保存
+                            val member = alreadyFriendData.find { it.id.equals(friendId) }
+                            if(member != null) {
+                                RoomLocalDBService().addRoom(
+                                        roomId,
+                                        member.name,
+                                        member.pathToFile,
+                                        room.createdAt,
+                                        false,
+                                        -1,
+                                        "",
+                                        Timestamp(0L),
+                                        rdb, this)
+                            } else {
+                                debugLog(this, "something wrong in find member from data")
+                            }
+
+                            // ルームメンバーのlocalDBへの保存
+                            RoomLocalDBService().addRoomMembers(roomId, arrayListOf(userId, friendId), rdb, this)
+
+                            debugLog(this, "add room!")
+                        }
+                    }
+                }, {
+                    debugLog(this, "add room failed: $it")
+                })
+    }
+
+    private fun goToTalk(roomId: String, name: String) {
         val intent = Intent(this, TalkActivity::class.java)
         intent.putExtra("roomName", name)
         intent.putExtra("userId", userId)
-        intent.putExtra("roomId", roomId.toString())
+        intent.putExtra("roomId", roomId)
         startActivity(intent)
         finish()
     }

--- a/app/src/main/java/intern/line/tokyoaclient/ConfigureGroupAcitvity.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/ConfigureGroupAcitvity.kt
@@ -1,0 +1,295 @@
+package intern.line.tokyoaclient
+
+import android.app.Activity
+import android.content.ContentValues
+import android.content.Intent
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteException
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.os.Bundle
+import android.os.ParcelFileDescriptor
+import android.support.v7.app.AppCompatActivity
+import android.view.KeyEvent
+import android.widget.*
+import com.bumptech.glide.Glide
+import intern.line.tokyoaclient.Adapter.UserListAdapterWithImage
+import intern.line.tokyoaclient.HttpConnection.imageService
+import intern.line.tokyoaclient.HttpConnection.model.UserProfileWithImageUrl
+import intern.line.tokyoaclient.HttpConnection.roomService
+import intern.line.tokyoaclient.LocalDataBase.FriendDBHelper
+import intern.line.tokyoaclient.LocalDataBase.RoomDBHelper
+import intern.line.tokyoaclient.LocalDataBase.RoomLocalDBService
+import intern.line.tokyoaclient.LocalDataBase.TalkDBHelper
+import okhttp3.MediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import rx.android.schedulers.AndroidSchedulers
+import rx.schedulers.Schedulers
+import java.io.ByteArrayOutputStream
+import java.io.FileDescriptor
+import java.io.IOException
+import java.sql.Time
+import java.sql.Timestamp
+import java.util.*
+import kotlin.collections.ArrayList
+
+
+class ConfigureGroupActivity : AppCompatActivity() {
+
+    private val RESULT_PICK_IMAGEFILE = 1001
+    private lateinit var userId: String
+    private lateinit var groupName: EditText
+    private lateinit var groupIconImageView: ImageView
+    private var defaultIcon = true
+    private lateinit var groupMemberList: ListView
+    private var adapter: UserListAdapterWithImage? = null
+    private lateinit var data: ArrayList<UserProfileWithImageUrl>
+    private var countDown = 0
+    private var bmp: Bitmap? = null
+    // localDB
+    private lateinit var fdb: SQLiteDatabase
+    private lateinit var friendHelper: FriendDBHelper
+    private lateinit var rdb: SQLiteDatabase
+    private lateinit var roomHelper: RoomDBHelper
+    private lateinit var tdb: SQLiteDatabase
+    private lateinit var talkHelper: TalkDBHelper
+
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_configure_group)
+
+        groupMemberList = (findViewById(R.id.groupMembers) as ListView)
+        data = ArrayList()
+        userId = intent.getStringExtra("userId")
+        val userIds = intent.getStringArrayExtra("userIds")
+        val userNames = intent.getStringArrayExtra("userNames")
+        val userIcons = intent.getStringArrayExtra("userIcons")
+        for (i in 0..userIds.size-1) {
+            data.add(UserProfileWithImageUrl(userIds[i], userNames[i], userIcons[i]))
+        }
+        adapter = UserListAdapterWithImage(this, data)
+        groupMemberList.setAdapter(adapter)
+
+        groupName = findViewById(R.id.groupName) as EditText
+        groupIconImageView = findViewById(R.id.groupIcon) as ImageView
+        Glide.with(this).load("http://ec2-52-197-250-179.ap-northeast-1.compute.amazonaws.com/image/url/" + "default.jpg").into(groupIconImageView)
+
+        if (USE_LOCAL_DB) {
+            try {
+                friendHelper = FriendDBHelper(this)
+                roomHelper = RoomDBHelper(this)
+                talkHelper = TalkDBHelper(this)
+            } catch (e: SQLiteException) {
+                Toast.makeText(this, "helper error: ${e.toString()}", Toast.LENGTH_SHORT).show()
+                println("helper error: ${e.toString()}")
+            }
+
+            try {
+                fdb = friendHelper.writableDatabase
+                rdb = roomHelper.writableDatabase
+                tdb = talkHelper.writableDatabase
+                Toast.makeText(this, "accessed to database", Toast.LENGTH_SHORT).show()
+            } catch (e: SQLiteException) {
+                Toast.makeText(this, "writable error: ${e.toString()}", Toast.LENGTH_SHORT).show()
+                println("writable error: ${e.toString()}")
+            }
+        } else {
+            this.deleteDatabase(FriendDBHelper(this).databaseName)
+            this.deleteDatabase(RoomDBHelper(this).databaseName)
+            this.deleteDatabase(TalkDBHelper(this).databaseName)
+        }
+        
+        groupIconImageView.setOnClickListener {
+            openGallery()
+        }
+
+        var createButton = findViewById(R.id.createButton) as Button
+        createButton.setOnClickListener {
+            createGroup(data)
+        }
+    }
+
+    override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            // 戻るボタンが押されたときの処理
+            finish()
+        }
+        return super.onKeyDown(keyCode, event)
+    }
+
+    private fun createGroup(groupMembers: ArrayList<UserProfileWithImageUrl>) {
+        if(groupName.text.toString() == "") {
+            groupName.error = "なにか入力してください"
+        } else {
+            val roomId = UUID.randomUUID().toString()
+            val roomName = groupName.text.toString()
+            roomService.addRoomAsGroup(roomId, roomName)
+                    .subscribeOn(Schedulers.io())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe({
+                        if(!defaultIcon)
+                            addIcon(roomId)
+                        else
+                            addDefaultIcon(roomId)
+                        countDown = data.size
+                        for (s in data) {
+                            addMemberToRoom(s.id, roomId)
+                        }
+                        addMemberToRoom(userId, roomId) // 自分
+                        while(countDown > 0) {
+                            println("Creating group ... $countDown")
+                        }
+                        if(USE_LOCAL_DB) {
+                            val groupMembers: ArrayList<String> = ArrayList()
+                            groupMembers.addAll(data.map { it -> it.id })
+                            groupMembers.add(userId)
+                            addGroupToLocalDB(groupMembers, roomId, roomName)
+                        }
+                        // グループメンバー選択画面へのintent
+                        var intent = Intent()
+                        setResult(Activity.RESULT_OK, intent)
+                        finish()
+                    }, {
+                        Toast.makeText(this, "create group failed: $it", Toast.LENGTH_LONG).show()
+                        println("create group failed: $it")
+                    })
+        }
+    }
+
+    fun addIcon(roomId: String) {
+        groupIconImageView.setImageBitmap(null)
+        try {
+            val content = bitmapToByteArray(bmp) // ByteArray
+            val requestFile = RequestBody.create(MediaType.parse("multipart/form-data"), content);
+            val body = MultipartBody.Part.createFormData("file", "hoge.jpg", requestFile); // 第一引数はサーバ側の@RequestParamの名前と一致させる
+
+            imageService.addImage(roomId, body)
+                    .subscribeOn(Schedulers.io())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe({
+                        Toast.makeText(this, "put image succeeded", Toast.LENGTH_SHORT).show()
+                        println("put image succeeded")
+                        finish()
+                    }, {
+                        Toast.makeText(this, "put image failed: $it", Toast.LENGTH_SHORT).show()
+                        println("put image failed: $it")
+                    })
+        } catch (e: IOException) {
+            e.printStackTrace()
+        }
+    }
+
+    fun addDefaultIcon(roomId: String) {
+        imageService.addDefaultImage(roomId)
+                    .subscribeOn(Schedulers.io())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe({
+                        Toast.makeText(this, "put image succeeded", Toast.LENGTH_SHORT).show()
+                        println("put image succeeded")
+                        finish()
+                    }, {
+                        Toast.makeText(this, "put image failed: $it", Toast.LENGTH_SHORT).show()
+                        println("put image failed: $it")
+                    })
+    }
+
+    private fun addMemberToRoom(userId: String, roomId: String) {
+        roomService.addRoomMember(roomId, userId)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                }, {
+                    Toast.makeText(this, "add room member failed: $it", Toast.LENGTH_LONG).show()
+                    println("add room member failed: $it")
+                })
+        countDown--
+    }
+
+    private fun addGroupToLocalDB(groupMemberUserIds: ArrayList<String>, roomId: String, roomName: String) {
+        // ルームの情報を取得してから，localDBに保存
+        roomService.getRoomByRoomId(roomId)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                    val room = it
+                    imageService.getImageUrlById(roomId)
+                            .subscribeOn(Schedulers.io())
+                            .observeOn(AndroidSchedulers.mainThread())
+                            .subscribe({
+                                val pathToFile = it.pathToFile
+                                RoomLocalDBService().getRoomById(roomId, rdb, this) {
+                                    if (it.count == 0) { // ルームがまだ存在していなければ
+                                        // ルームのlocalDBへの保存
+                                        RoomLocalDBService().addRoom(
+                                                roomId,
+                                                roomName,
+                                                pathToFile,
+                                                room.createdAt,
+                                                true,
+                                                -1,
+                                                "",
+                                                Timestamp(0L),
+                                                rdb, this)
+
+                                        // ルームメンバーのlocalDBへの保存
+                                        RoomLocalDBService().addRoomMembers(roomId, groupMemberUserIds, rdb, this)
+
+                                        debugLog(this, "add group room!")
+                                    }
+                                }
+                            }, {
+                                debugLog(this, "get image url failed: $it")
+                            })
+                }, {
+                    debugLog(this, "get room failed: $it")
+                })
+    }
+
+    private fun openGallery() {
+        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT)
+        intent.addCategory(Intent.CATEGORY_OPENABLE)
+        intent.setType("*/*")
+        startActivityForResult(intent, RESULT_PICK_IMAGEFILE)
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, resultData: Intent?) {
+        if(requestCode == RESULT_PICK_IMAGEFILE && resultCode == Activity.RESULT_OK) {
+            if(resultData?.getData() != null) {
+                var pfDescripor: ParcelFileDescriptor? = null
+                try {
+                    val uri: Uri = resultData.getData()
+                    pfDescripor = contentResolver.openFileDescriptor(uri, "r")
+                    if(pfDescripor != null) {
+                        var fileDescriptor: FileDescriptor = pfDescripor.fileDescriptor
+                        bmp = BitmapFactory.decodeFileDescriptor(fileDescriptor)
+                        pfDescripor.close()
+                        groupIconImageView.setImageBitmap(bmp)
+                    }
+                    defaultIcon = false
+                } catch(e: IOException) {
+                    e.printStackTrace()
+                } finally {
+                    try {
+                        if(pfDescripor != null) {
+                            pfDescripor.close()
+                        }
+                    } catch(e: Exception) {
+                        e.printStackTrace()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun bitmapToByteArray (bitmap: Bitmap?): ByteArray {
+        var byteArrayOutputStream = ByteArrayOutputStream()
+
+        // PNG, クオリティー100としてbyte配列にデータを格納
+        bitmap?.compress(Bitmap.CompressFormat.PNG, 100, byteArrayOutputStream)
+
+        return byteArrayOutputStream.toByteArray()
+    }
+}

--- a/app/src/main/java/intern/line/tokyoaclient/CreateGroupActivity.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/CreateGroupActivity.kt
@@ -1,0 +1,173 @@
+package intern.line.tokyoaclient
+
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteException
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import android.widget.*
+import intern.line.tokyoaclient.Adapter.NameComparator
+import intern.line.tokyoaclient.Adapter.UserListAdapterWithImageSelection
+import intern.line.tokyoaclient.HttpConnection.friendService
+import intern.line.tokyoaclient.HttpConnection.imageService
+import intern.line.tokyoaclient.HttpConnection.model.UserProfileWithImageUrl
+import intern.line.tokyoaclient.HttpConnection.userProfileService
+import intern.line.tokyoaclient.LocalDataBase.FriendDBHelper
+import rx.android.schedulers.AndroidSchedulers
+import rx.schedulers.Schedulers
+import java.util.*
+import kotlin.collections.ArrayList
+
+
+class CreateGroupActivity : AppCompatActivity() {
+
+    private var userId: String = "default"
+    private lateinit var friendList: ListView
+    private lateinit var counter: TextView
+    private var count = 0
+    private lateinit var selectedUserId: ArrayList<String>
+    private var adapter: UserListAdapterWithImageSelection? = null
+    private lateinit var data: ArrayList<UserProfileWithImageUrl>
+    // localDB
+    private lateinit var fdb: SQLiteDatabase
+    private lateinit var helper: FriendDBHelper
+
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_create_group)
+
+        friendList = (findViewById(R.id.friendList) as ListView)
+        counter = (findViewById(R.id.counter) as TextView)
+        count = 0
+        selectedUserId = ArrayList()
+        data = ArrayList()
+        adapter = UserListAdapterWithImageSelection(this, data)
+        friendList.setAdapter(adapter)
+
+        userId = intent.getStringExtra("userId")
+
+        if (USE_LOCAL_DB) {
+            try {
+                helper = FriendDBHelper(this)
+            } catch (e: SQLiteException) {
+                Toast.makeText(this, "helper error: ${e.toString()}", Toast.LENGTH_SHORT).show()
+                println("helper error: ${e.toString()}")
+            }
+
+            try {
+                fdb = helper.readableDatabase
+                Toast.makeText(this, "accessed to database", Toast.LENGTH_SHORT).show()
+            } catch (e: SQLiteException) {
+                Toast.makeText(this, "readable error: ${e.toString()}", Toast.LENGTH_SHORT).show()
+                println("readable error: ${e.toString()}")
+            }
+        } else {
+            this.deleteDatabase(FriendDBHelper(this).databaseName)
+        }
+
+        if (USE_LOCAL_DB) {
+            getFriendByLocalDB()
+        } else {
+            getFriend(userId)
+        }
+
+        val createButton = findViewById(R.id.createButton) as Button
+        createButton.setOnClickListener {
+            createGroup(selectedUserId)
+        }
+
+        friendList.setOnItemClickListener { _, view, position, _ ->
+            val check = view.findViewById<CheckedTextView>(R.id.nameTextView)
+            if (check.isChecked) {
+                selectedUserId.remove(data[position].id)
+                count--;
+            } else {
+                count++;
+                selectedUserId.add(data[position].id)
+            }
+            counter.text = count.toString()
+            check.toggle()
+        }
+    }
+
+    private fun getFriend(userId: String) {
+        adapter?.clear()
+        friendService.getFriendById(userId)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                    for (s in it) {
+                        getFriendName(s.friendId)
+                    }
+                    // Toast.makeText(context, "get friend list succeeded", Toast.LENGTH_SHORT).show()
+                    // println("get friend list succeeded: $it")
+                }, {
+                    Toast.makeText(this, "get friend list failed: $it", Toast.LENGTH_LONG).show()
+                    println("get friend list failed: $it")
+                })
+    }
+
+    private fun getFriendByLocalDB() {
+        adapter?.clear() // 空にする
+        val sqlstr = "select * from friends"
+        val cursor = fdb.rawQuery(sqlstr, null)
+        cursor.moveToPosition(-1)
+        while (cursor.moveToNext()) {
+            getFriendNameByLocalDB(cursor.getString(0))
+        }
+        adapter?.notifyDataSetChanged()
+    }
+
+    private fun getFriendName(friendId: String) { // idを引数に、nameをゲットする関数。ユーザー情報のGET/POSTメソッドはどっかに分離したほうがわかりやすそう。
+        userProfileService.getUserById(friendId)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                    // Toast.makeText(context, "get name succeeded", Toast.LENGTH_SHORT).show()
+                    // println("get name succeeded: $it")
+                    getIcon(it.id, it.name)
+                }, {
+                    Toast.makeText(this, "get name failed: $it", Toast.LENGTH_LONG).show()
+                    println("get name failed: $it")
+                })
+    }
+
+    private fun getIcon(idStr: String, nameStr: String) {
+        imageService.getImageUrlById(idStr)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                    // Toast.makeText(context, "get image url succeeded: $it", Toast.LENGTH_SHORT).show()
+                    // println("get image url succeeded: $it")
+                    if (it.pathToFile != "") {
+                        adapter?.addAll(UserProfileWithImageUrl(idStr, nameStr, it.pathToFile))
+                    } else {
+                        adapter?.addAll(UserProfileWithImageUrl(idStr, nameStr, "default.jpg"))
+                    }
+                    Collections.sort(data, NameComparator())
+                }, {
+                    adapter?.addAll(UserProfileWithImageUrl(idStr, nameStr, "default.jpg"))
+                    Collections.sort(data, NameComparator())
+                    Toast.makeText(this, "get image url failed: $it", Toast.LENGTH_LONG).show()
+                    println("get image url failed: $it")
+                })
+    }
+
+    private fun getFriendNameByLocalDB(friendId: String) { // idを引数に、nameをゲットする関数。ユーザー情報のGET/POSTメソッドはどっかに分離したほうがわかりやすそう。
+        println("get friend from localDB")
+        val sqlstr = "select * from friend_data where id = '$friendId'"
+        val cursor = fdb.rawQuery(sqlstr, null)
+        cursor.moveToPosition(-1)
+        while (cursor.moveToNext()) {
+            adapter?.add(UserProfileWithImageUrl(
+                    id = cursor.getString(0), // id
+                    name = cursor.getString(1), // name
+                    pathToFile = cursor.getString(2)
+            )) // created_atとupdated_atはdefault値．今後created_atとupdated_atが重要になってきたら変更しないといけない
+        }
+    }
+
+    private fun createGroup(userIds: ArrayList<String>) {
+
+    }
+}

--- a/app/src/main/java/intern/line/tokyoaclient/EditIconActivity.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/EditIconActivity.kt
@@ -8,6 +8,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.os.ParcelFileDescriptor
 import android.support.v7.app.AppCompatActivity
+import android.view.KeyEvent
 import android.widget.*
 import intern.line.tokyoaclient.HttpConnection.imageService
 import kotlinx.android.synthetic.main.activity_edit_icon.*
@@ -50,6 +51,14 @@ class EditIconActivity : AppCompatActivity() {
         applyButton.setOnClickListener {
             updateIcon()
         }
+    }
+
+    override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            // 戻るボタンが押されたときの処理
+            finish()
+        }
+        return super.onKeyDown(keyCode, event)
     }
 
     private fun openGallery() {

--- a/app/src/main/java/intern/line/tokyoaclient/EditNameActivity.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/EditNameActivity.kt
@@ -2,10 +2,12 @@ package intern.line.tokyoaclient
 
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
+import android.view.KeyEvent
 import android.widget.*
 import intern.line.tokyoaclient.HttpConnection.userProfileService
 import rx.android.schedulers.AndroidSchedulers
 import rx.schedulers.Schedulers
+
 
 class EditNameActivity : AppCompatActivity() {
 
@@ -26,6 +28,14 @@ class EditNameActivity : AppCompatActivity() {
         applyButton.setOnClickListener {
             changeName(userId, (findViewById(R.id.nameText) as TextView).text.toString())
         }
+    }
+
+    override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
+        if (keyCode == KeyEvent.KEYCODE_BACK) {
+            // 戻るボタンが押されたときの処理
+            finish()
+        }
+        return super.onKeyDown(keyCode, event)
     }
 
     private fun changeName(userId: String, newName: String){

--- a/app/src/main/java/intern/line/tokyoaclient/Fragment/FriendListFragment.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/Fragment/FriendListFragment.kt
@@ -17,70 +17,90 @@ import intern.line.tokyoaclient.Adapter.NameComparator
 import intern.line.tokyoaclient.Adapter.UserListAdapterWithImage
 import intern.line.tokyoaclient.HttpConnection.*
 import intern.line.tokyoaclient.HttpConnection.model.UserProfileWithImageUrl
-import intern.line.tokyoaclient.LocalDataBase.FriendDBHelper
+import intern.line.tokyoaclient.LocalDataBase.*
 import rx.android.schedulers.AndroidSchedulers
 import rx.schedulers.Schedulers
+import java.sql.Timestamp
 import java.util.*
 import kotlin.collections.ArrayList
 
 
-private lateinit var friendList: ListView
-private lateinit var addFriendButton: Button
-private lateinit var createGroupButton: Button
-private lateinit var userIconImageView: ImageView
-private var adapter: UserListAdapterWithImage? = null
-private lateinit var data: ArrayList<UserProfileWithImageUrl>
-
-private lateinit var userId: String
-
 class FriendListFragment : Fragment() {
-    private lateinit var v: View
+    private lateinit var userId: String
+    private lateinit var data: ArrayList<UserProfileWithImageUrl>
+    private var adapter: UserListAdapterWithImage? = null
     // localDB
     private lateinit var fdb: SQLiteDatabase
-    private lateinit var helper: FriendDBHelper
+    private lateinit var friendHelper: FriendDBHelper
+    private lateinit var rdb: SQLiteDatabase
+    private lateinit var roomHelper: RoomDBHelper
+    private lateinit var sdb: SQLiteDatabase
+    private lateinit var selfInfoHelper: SelfInfoDBHelper
 
     private val REQUEST_ADD_FRIEND = 1 // request code
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
-                              savedInstanceState: Bundle?): View? {
-        // Inflate the layout for this fragment
-        v = inflater.inflate(R.layout.fragment_friend_list, container, false)
-        //MyPagerAdapterで設定しておいたargumentsを取得
-        userId = arguments!!.getString("userId")
-        addFriendButton = v.findViewById(R.id.addFriendButton) as Button
-        createGroupButton = v.findViewById(R.id.createGroupButton) as Button
-        friendList = v.findViewById(R.id.friendList) as ListView
-        userIconImageView = v.findViewById(R.id.icon) as ImageView
+    override fun onCreate(savedInstanceState: Bundle?) { // 最初の1回だけ呼ばれる
+        super.onCreate(savedInstanceState)
 
-        data = ArrayList()
-        adapter = UserListAdapterWithImage(context!!, data)
-        friendList.setAdapter(adapter)
-
+        // localDBのセットアップ
         if (USE_LOCAL_DB) {
             try {
-                helper = FriendDBHelper(context)
+                friendHelper = FriendDBHelper(context)
+                roomHelper = RoomDBHelper(context)
+                selfInfoHelper = SelfInfoDBHelper(context)
             } catch (e: SQLiteException) {
-                Toast.makeText(context, "helper error: ${e.toString()}", Toast.LENGTH_SHORT).show()
-                println("helper error: ${e.toString()}")
+                debugLog(context, "helper error: ${e.toString()}")
             }
 
             try {
-                fdb = helper.readableDatabase
+                fdb = friendHelper.readableDatabase
+                rdb = roomHelper.writableDatabase
+                sdb = selfInfoHelper.writableDatabase
                 Toast.makeText(context, "accessed to database", Toast.LENGTH_SHORT).show()
             } catch (e: SQLiteException) {
-                Toast.makeText(context, "readable error: ${e.toString()}", Toast.LENGTH_SHORT).show()
-                println("readable error: ${e.toString()}")
+                debugLog(context, "readable error: ${e.toString()}")
             }
         } else {
             context!!.deleteDatabase(FriendDBHelper(context).databaseName)
+            context!!.deleteDatabase(RoomDBHelper(context).databaseName)
+            context!!.deleteDatabase(TalkDBHelper(context).databaseName)
+            Toast.makeText(context, "deleted database", Toast.LENGTH_SHORT).show()
         }
 
+        //MyPagerAdapterで設定しておいたargumentsを取得
+        userId = arguments!!.getString("userId")
         getOwnName(userId)
+        getOwnIcon(userId)
+
+        // フレンドの取得
+        data = ArrayList()
+        adapter = UserListAdapterWithImage(context!!, data)
         if (USE_LOCAL_DB) {
             getFriendByLocalDB()
         } else {
             getFriend(userId)
         }
+    }
+
+    private lateinit var v: View
+    private lateinit var friendList: ListView
+    private lateinit var addFriendButton: Button
+    private lateinit var createGroupButton: Button
+    private lateinit var userIconImageView: ImageView
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
+                              savedInstanceState: Bundle?): View? {
+        // Inflate the layout for this fragment
+        v = inflater.inflate(R.layout.fragment_friend_list, container, false)
+
+        addFriendButton = v.findViewById(R.id.addFriendButton) as Button
+        createGroupButton = v.findViewById(R.id.createGroupButton) as Button
+        friendList = v.findViewById(R.id.friendList) as ListView
+        userIconImageView = v.findViewById(R.id.icon) as ImageView
+
+        getOwnName(userId)
+        getOwnIcon(userId)
+        friendList.setAdapter(adapter)
 
         addFriendButton.setOnClickListener {
             goToAddFriend(userId)
@@ -93,10 +113,58 @@ class FriendListFragment : Fragment() {
             val num1: Int = Math.abs(UUID.nameUUIDFromBytes(userId.toByteArray()).hashCode())
             val num2: Int = Math.abs(UUID.nameUUIDFromBytes(friendId.toByteArray()).hashCode())
             val roomId: String = (num1 + num2).toString()
-            addMemberToRoomAfterCreateRoom(arrayListOf(userId, friendId), roomId)
+            // val roomId: String = UUID.randomUUID().toString()
+            addMemberToRoomAfterCreateRoom(userId, friendId, roomId)
             goToTalk(roomId, view.findViewById<TextView>(R.id.nameTextView).text.toString())
         }
         return v
+    }
+
+    private fun getOwnName(idStr: String) { // idを引数に、nameをゲットする関数。ユーザー情報のGET/POSTメソッドはどっかに分離したほうがわかりやすそう。
+        userProfileService.getUserById(idStr)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                    (v.findViewById(R.id.ownNameText) as TextView).text = it.name
+                    if(USE_LOCAL_DB)
+                        addSelfInfoToLocalDB(it.name)
+                }, {
+                    debugLog(context, "get name failed: $it")
+                })
+    }
+
+    private fun addSelfInfoToLocalDB(name: String) {
+        SelfInfoLocalDBService().getInfo(sdb) {
+            if(!it.moveToNext()) { // まだ登録されていなかったら
+                SelfInfoLocalDBService().addInfo(userId, name, "default.jpg", sdb, context)
+            }
+        }
+    }
+
+    private fun getOwnIcon(idStr: String) {
+        imageService.getImageUrlById(idStr)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                    if (it.pathToFile != "") {
+                        Glide.with(context).load("http://ec2-52-197-250-179.ap-northeast-1.compute.amazonaws.com/image/url/" + it.pathToFile).into(userIconImageView)
+                    } else {
+                        Glide.with(context).load("http://ec2-52-197-250-179.ap-northeast-1.compute.amazonaws.com/image/url/" + "default.jpg").into(userIconImageView)
+                    }
+                }, {
+                    debugLog(context, "get image url failed: $it")
+                })
+    }
+
+    private fun getFriendByLocalDB() {
+        adapter?.clear() // 空にする
+        FriendLocalDBService().getAllFriend(fdb, context) {
+            adapter?.add(UserProfileWithImageUrl(
+                    id = it.getString(0),
+                    name = it.getString(1),
+                    pathToFile = it.getString(2)))
+        }
+        adapter?.notifyDataSetChanged()
     }
 
     private fun getFriend(userId: String) {
@@ -108,55 +176,8 @@ class FriendListFragment : Fragment() {
                     for (s in it) {
                         getFriendName(s.friendId)
                     }
-                    // Toast.makeText(context, "get friend list succeeded", Toast.LENGTH_SHORT).show()
-                    // println("get friend list succeeded: $it")
                 }, {
-                    Toast.makeText(context, "get friend list failed: $it", Toast.LENGTH_LONG).show()
-                    println("get friend list failed: $it")
-                })
-    }
-
-    private fun getFriendByLocalDB() {
-        adapter?.clear() // 空にする
-        val sqlstr = "select * from friends"
-        val cursor = fdb.rawQuery(sqlstr, null)
-        cursor.moveToPosition(-1)
-        while (cursor.moveToNext()) {
-            getFriendNameByLocalDB(cursor.getString(0))
-        }
-        adapter?.notifyDataSetChanged()
-    }
-
-    private fun getOwnName(idStr: String) { // idを引数に、nameをゲットする関数。ユーザー情報のGET/POSTメソッドはどっかに分離したほうがわかりやすそう。
-        userProfileService.getUserById(idStr)
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe({
-                    // Toast.makeText(context, "get name succeeded", Toast.LENGTH_SHORT).show()
-                    // println("get name succeeded: $it")
-                    (v.findViewById(R.id.ownNameText) as TextView).text = it.name
-                    getOwnIcon(idStr)
-                }, {
-                    Toast.makeText(context, "get name failed: $it", Toast.LENGTH_LONG).show()
-                    println("get name failed: $it")
-                })
-    }
-
-    private fun getOwnIcon(idStr: String) {
-        imageService.getImageUrlById(idStr)
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe({
-                    // Toast.makeText(context, "get image url succeeded: $it", Toast.LENGTH_SHORT).show()
-                    // println("get image url succeeded: $it")
-                    if (it.pathToFile != "") {
-                        Glide.with(context).load("http://ec2-52-197-250-179.ap-northeast-1.compute.amazonaws.com/image/url/" + it.pathToFile).into(userIconImageView)
-                    } else {
-                        Glide.with(context).load("http://ec2-52-197-250-179.ap-northeast-1.compute.amazonaws.com/image/url/" + "default.jpg").into(userIconImageView)
-                    }
-                }, {
-                    Toast.makeText(context, "get image url failed: $it", Toast.LENGTH_LONG).show()
-                    println("get image url failed: $it")
+                    debugLog(context, "get friend list failed: $it")
                 })
     }
 
@@ -165,22 +186,17 @@ class FriendListFragment : Fragment() {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
-                    // Toast.makeText(context, "get name succeeded", Toast.LENGTH_SHORT).show()
-                    // println("get name succeeded: $it")
-                    getIcon(it.id, it.name)
+                    getFriendIcon(it.id, it.name)
                 }, {
-                    Toast.makeText(context, "get name failed: $it", Toast.LENGTH_LONG).show()
-                    println("get name failed: $it")
+                    debugLog(context, "get name failed: $it")
                 })
     }
 
-    private fun getIcon(idStr: String, nameStr: String) {
+    private fun getFriendIcon(idStr: String, nameStr: String) {
         imageService.getImageUrlById(idStr)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
-                    // Toast.makeText(context, "get image url succeeded: $it", Toast.LENGTH_SHORT).show()
-                    // println("get image url succeeded: $it")
                     if (it.pathToFile != "") {
                         adapter?.addAll(UserProfileWithImageUrl(idStr, nameStr, it.pathToFile))
                     } else {
@@ -188,49 +204,74 @@ class FriendListFragment : Fragment() {
                     }
                     Collections.sort(data, NameComparator())
                 }, {
+                    debugLog(context, "get image url failed: $it")
                     adapter?.addAll(UserProfileWithImageUrl(idStr, nameStr, "default.jpg"))
                     Collections.sort(data, NameComparator())
-                    Toast.makeText(context, "get image url failed: $it", Toast.LENGTH_LONG).show()
-                    println("get image url failed: $it")
                 })
     }
 
-    private fun getFriendNameByLocalDB(friendId: String) { // idを引数に、nameをゲットする関数。ユーザー情報のGET/POSTメソッドはどっかに分離したほうがわかりやすそう。
-        println("get friend from localDB")
-        val sqlstr = "select * from friend_data where id = '$friendId'"
-        val cursor = fdb.rawQuery(sqlstr, null)
-        cursor.moveToPosition(-1)
-        while (cursor.moveToNext()) {
-            adapter?.add(UserProfileWithImageUrl(
-                    id = cursor.getString(0), // id
-                    name = cursor.getString(1), // name
-                    pathToFile = cursor.getString(2)
-            )) // created_atとupdated_atはdefault値．今後created_atとupdated_atが重要になってきたら変更しないといけない
-        }
-    }
-
-    private fun addMemberToRoomAfterCreateRoom(userIds: ArrayList<String>, roomId: String) {
+    private fun addMemberToRoomAfterCreateRoom(userId: String, friendId: String, roomId: String) {
+        // ルームの登録
         roomService.addRoom(roomId, "default_room")
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
-                    for(u in userIds) {
+                    for(u in arrayListOf(userId, friendId)) {
                         addMemberToRoom(u, roomId)
                     }
+                    if(USE_LOCAL_DB)
+                        addGroupToLocalDB(userId, friendId, roomId, "default_room")
                 }, {
-                    Toast.makeText(context, "add room url failed: $it", Toast.LENGTH_LONG).show()
-                    println("add room failed: $it")
+                    debugLog(context, "add room failed: $it")
                 })
     }
 
     private fun addMemberToRoom(userId: String, roomId: String) {
+        // ルームメンバー（自分とフレンド）の登録
         roomService.addRoomMember(roomId, userId)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
                 }, {
-                    Toast.makeText(context, "add room member url failed: $it", Toast.LENGTH_LONG).show()
+                    Toast.makeText(context, "add room member failed: $it", Toast.LENGTH_LONG).show()
                     println("add room member failed: $it")
+                })
+    }
+
+    private fun addGroupToLocalDB(userId: String, friendId: String, roomId: String, roomName: String) {
+        // ルームの情報を取得してから，localDBに保存
+        roomService.getRoomByRoomId(roomId)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                    val room = it
+                    RoomLocalDBService().getRoomById(roomId, rdb, context) {
+                        if(it.count == 0) { // ルームがまだ存在していなければ
+                            // ルームのlocalDBへの保存
+                            val member = data.find { it.id.equals(friendId) }
+                            if(member != null) {
+                                RoomLocalDBService().addRoom(
+                                        roomId,
+                                        member.name,
+                                        member.pathToFile,
+                                        room.createdAt,
+                                        false,
+                                        -1,
+                                        "",
+                                        Timestamp(0L),
+                                        rdb, context)
+                            } else {
+                                debugLog(context, "something wrong in find member from data")
+                            }
+
+                            // ルームメンバーのlocalDBへの保存
+                            RoomLocalDBService().addRoomMembers(roomId, arrayListOf(userId, friendId), rdb, context)
+
+                            debugLog(context, "add room!")
+                        }
+                    }
+                }, {
+                    debugLog(context, "add room failed: $it")
                 })
     }
 
@@ -255,7 +296,6 @@ class FriendListFragment : Fragment() {
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        // super.onActivityResult(requestCode, resultCode, data)
         if(requestCode == REQUEST_ADD_FRIEND && resultCode == RESULT_OK) {
             if(data != null) {
                 getFriendName(data.getStringExtra("newFriendId"))

--- a/app/src/main/java/intern/line/tokyoaclient/Fragment/FriendListFragment.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/Fragment/FriendListFragment.kt
@@ -1,4 +1,4 @@
-package intern.line.tokyoaclient
+package intern.line.tokyoaclient.Fragment
 
 
 import android.app.Activity.RESULT_OK
@@ -12,10 +12,11 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.*
 import com.bumptech.glide.Glide
+import intern.line.tokyoaclient.*
+import intern.line.tokyoaclient.Adapter.NameComparator
+import intern.line.tokyoaclient.Adapter.UserListAdapterWithImage
 import intern.line.tokyoaclient.HttpConnection.*
 import intern.line.tokyoaclient.HttpConnection.model.UserProfileWithImageUrl
-import kotlinx.android.synthetic.main.fragment_setting.*
-import intern.line.tokyoaclient.HttpConnection.model.UserProfile
 import intern.line.tokyoaclient.LocalDataBase.FriendDBHelper
 import rx.android.schedulers.AndroidSchedulers
 import rx.schedulers.Schedulers
@@ -25,6 +26,7 @@ import kotlin.collections.ArrayList
 
 private lateinit var friendList: ListView
 private lateinit var addFriendButton: Button
+private lateinit var createGroupButton: Button
 private lateinit var userIconImageView: ImageView
 private var adapter: UserListAdapterWithImage? = null
 private lateinit var data: ArrayList<UserProfileWithImageUrl>
@@ -46,6 +48,7 @@ class FriendListFragment : Fragment() {
         //MyPagerAdapterで設定しておいたargumentsを取得
         userId = arguments!!.getString("userId")
         addFriendButton = v.findViewById(R.id.addFriendButton) as Button
+        createGroupButton = v.findViewById(R.id.createGroupButton) as Button
         friendList = v.findViewById(R.id.friendList) as ListView
         userIconImageView = v.findViewById(R.id.icon) as ImageView
 
@@ -82,7 +85,10 @@ class FriendListFragment : Fragment() {
         addFriendButton.setOnClickListener {
             goToAddFriend(userId)
         }
-        friendList.setOnItemClickListener { adapterView, view, position, id ->
+        createGroupButton.setOnClickListener {
+            goToCreateGroup(userId)
+        }
+        friendList.setOnItemClickListener { _, view, _, _ ->
             val friendId = view.findViewById<TextView>(R.id.idTextView).text.toString()
             val num1: Int = Math.abs(UUID.nameUUIDFromBytes(userId.toByteArray()).hashCode())
             val num2: Int = Math.abs(UUID.nameUUIDFromBytes(friendId.toByteArray()).hashCode())
@@ -239,6 +245,12 @@ class FriendListFragment : Fragment() {
         intent.putExtra("roomName", name)
         intent.putExtra("userId", userId)
         intent.putExtra("roomId", roomId.toString())
+        startActivity(intent)
+    }
+
+    private fun goToCreateGroup(userId: String) {
+        val intent = Intent(context, CreateGroupActivity::class.java)
+        intent.putExtra("userId", userId)
         startActivity(intent)
     }
 

--- a/app/src/main/java/intern/line/tokyoaclient/Fragment/SettingFragment.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/Fragment/SettingFragment.kt
@@ -2,6 +2,8 @@ package intern.line.tokyoaclient.Fragment
 
 
 import android.content.Intent
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteException
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.view.LayoutInflater
@@ -12,48 +14,56 @@ import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
 import com.bumptech.glide.Glide
-import intern.line.tokyoaclient.EditIconActivity
-import intern.line.tokyoaclient.EditNameActivity
+import intern.line.tokyoaclient.*
 import intern.line.tokyoaclient.HttpConnection.imageService
 import intern.line.tokyoaclient.HttpConnection.userProfileService
-import intern.line.tokyoaclient.R
+import intern.line.tokyoaclient.LocalDataBase.SelfInfoDBHelper
+import intern.line.tokyoaclient.LocalDataBase.SelfInfoLocalDBService
 import rx.android.schedulers.AndroidSchedulers
 import rx.schedulers.Schedulers
 
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
-
-private lateinit var editNameButton: Button
-private lateinit var editIcon: ImageView
-private lateinit var userId: String
-
-/**
- * A simple [Fragment] subclass.
- *
- */
 class SettingFragment : Fragment() {
+    private lateinit var userId: String
+    // localDB
+    private lateinit var sdb: SQLiteDatabase
+    private lateinit var selfInfoHelper: SelfInfoDBHelper
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        userId = arguments!!.getString("userId")
+
+        if (USE_LOCAL_DB) {
+            try {
+                selfInfoHelper = SelfInfoDBHelper(context)
+            } catch (e: SQLiteException) {
+                debugLog(context, "helper error: ${e.toString()}")
+            }
+
+            try {
+                sdb = selfInfoHelper.readableDatabase
+                Toast.makeText(context, "accessed to database", Toast.LENGTH_SHORT).show()
+            } catch (e: SQLiteException) {
+                debugLog(context, "writable error: ${e.toString()}")
+            }
+        } else {
+            context?.deleteDatabase(SelfInfoDBHelper(context).databaseName)
+        }
+    }
 
     private lateinit var v: View
-    private lateinit var userName: String
+    private lateinit var editNameButton: Button
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
         // Inflate the layout for this fragment
         v = inflater.inflate(R.layout.fragment_setting, container, false)
-
-        userId = arguments!!.getString("userId")
-        getOwnName(userId)
-
         editNameButton = v.findViewById(R.id.editNameButton) as Button
         editNameButton.setOnClickListener {
             goNameEdit()
         }
 
         editIcon = v.findViewById(R.id.editIcon) as ImageView
-        getIcon(userId)
         editIcon.setOnClickListener {
             goIconEdit()
         }
@@ -61,19 +71,53 @@ class SettingFragment : Fragment() {
         return v
     }
 
+    private lateinit var userName: String
+    private lateinit var editIcon: ImageView
+
+    override fun onResume() {
+        super.onResume()
+        if(USE_LOCAL_DB) {
+            getNameAndIconByLocalDB()
+        } else {
+            getOwnName(userId)
+            getIcon(userId)
+        }
+    }
+
     private fun getOwnName(idStr: String) { // idを引数に、nameをゲットする関数。ユーザー情報のGET/POSTメソッドはどっかに分離したほうがわかりやすそう。
         userProfileService.getUserById(idStr)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
-                    Toast.makeText(context, "get name succeeded", Toast.LENGTH_SHORT).show()
-                    println("get name succeeded: $it")
                     (v.findViewById(R.id.userName) as TextView).text = it.name
                     userName = it.name
                 }, {
-                    Toast.makeText(context, "get name failed: $it", Toast.LENGTH_LONG).show()
-                    println("get name failed: $it")
+                    debugLog(context, "get name failed: $it")
                 })
+    }
+
+    private fun getIcon(idStr: String) {
+        imageService.getImageUrlById(idStr)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                    if(it.pathToFile != "") {
+                        Glide.with(context).load("http://ec2-52-197-250-179.ap-northeast-1.compute.amazonaws.com/image/url/" + it.pathToFile).into(editIcon)
+                    } else {
+                        Glide.with(context).load("http://ec2-52-197-250-179.ap-northeast-1.compute.amazonaws.com/image/url/" + "default.jpg").into(editIcon)
+                    }
+                }, {
+                    Glide.with(context).load("http://ec2-52-197-250-179.ap-northeast-1.compute.amazonaws.com/image/url/" + "default.jpg").into(editIcon)
+                    debugLog(context, "get image url failed: $it")
+                })
+    }
+
+    private fun getNameAndIconByLocalDB() {
+        SelfInfoLocalDBService().getInfo(sdb) {
+            it.moveToNext()
+            (v.findViewById(R.id.userName) as TextView).text = it.getString(1)
+            Glide.with(context).load("http://ec2-52-197-250-179.ap-northeast-1.compute.amazonaws.com/image/url/" + it.getString(2)).into(editIcon)
+        }
     }
 
     private fun goNameEdit() {
@@ -83,36 +127,10 @@ class SettingFragment : Fragment() {
         startActivity(intent)
     }
 
-
-    private fun getIcon(idStr: String) {
-        imageService.getImageUrlById(idStr)
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe({
-                    // Toast.makeText(context, "get image url succeeded: $it", Toast.LENGTH_SHORT).show()
-                    println("get image url succeeded: $it")
-                    if(it.pathToFile != "") {
-                        Glide.with(context).load("http://ec2-52-197-250-179.ap-northeast-1.compute.amazonaws.com/image/url/" + it.pathToFile).into(editIcon)
-                    } else {
-                        Glide.with(context).load("http://ec2-52-197-250-179.ap-northeast-1.compute.amazonaws.com/image/url/" + "default.jpg").into(editIcon)
-                    }
-                }, {
-                    Glide.with(context).load("http://ec2-52-197-250-179.ap-northeast-1.compute.amazonaws.com/image/url/" + "default.jpg").into(editIcon)
-                    // Toast.makeText(context, "get image url failed: $it", Toast.LENGTH_LONG).show()
-                    println("get image url failed: $it")
-                })
-    }
-
     private fun goIconEdit() {
         var intent = Intent(context, EditIconActivity::class.java)
         intent.putExtra("userId", userId)
         intent.putExtra("userName", userName)
         startActivity(intent)
-    }
-
-    override fun onResume() {
-        super.onResume()
-        getOwnName(userId)
-        getIcon(userId)
     }
 }

--- a/app/src/main/java/intern/line/tokyoaclient/Fragment/SettingFragment.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/Fragment/SettingFragment.kt
@@ -1,4 +1,4 @@
-package intern.line.tokyoaclient
+package intern.line.tokyoaclient.Fragment
 
 
 import android.content.Intent
@@ -12,8 +12,11 @@ import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
 import com.bumptech.glide.Glide
+import intern.line.tokyoaclient.EditIconActivity
+import intern.line.tokyoaclient.EditNameActivity
 import intern.line.tokyoaclient.HttpConnection.imageService
 import intern.line.tokyoaclient.HttpConnection.userProfileService
+import intern.line.tokyoaclient.R
 import rx.android.schedulers.AndroidSchedulers
 import rx.schedulers.Schedulers
 

--- a/app/src/main/java/intern/line/tokyoaclient/Fragment/TalkListFragment.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/Fragment/TalkListFragment.kt
@@ -2,6 +2,9 @@ package intern.line.tokyoaclient.Fragment
 
 
 import android.content.Intent
+import android.database.CursorIndexOutOfBoundsException
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteException
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.view.LayoutInflater
@@ -9,46 +12,87 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ListView
 import android.widget.Toast
+import intern.line.tokyoaclient.*
 import intern.line.tokyoaclient.Adapter.RoomAdapterWithImage
 import intern.line.tokyoaclient.Adapter.RoomComparator
 import intern.line.tokyoaclient.HttpConnection.imageService
 import intern.line.tokyoaclient.HttpConnection.model.RoomWithImageUrlAndLatestTalk
+import intern.line.tokyoaclient.HttpConnection.model.Talk
 import intern.line.tokyoaclient.HttpConnection.roomService
 import intern.line.tokyoaclient.HttpConnection.talkService
 import intern.line.tokyoaclient.HttpConnection.userProfileService
+import intern.line.tokyoaclient.LocalDataBase.*
 import intern.line.tokyoaclient.R
 import intern.line.tokyoaclient.TalkActivity
 import rx.android.schedulers.AndroidSchedulers
 import rx.schedulers.Schedulers
+import java.sql.Timestamp
 import java.util.*
-
-
-private lateinit var roomList: ListView
-private var adapter: RoomAdapterWithImage? = null
-private lateinit var data: ArrayList<RoomWithImageUrlAndLatestTalk>
-
-private var sinceTalkId = 0L
-private lateinit var userId: String
+import kotlin.collections.ArrayList
+import kotlin.concurrent.schedule
 
 
 class TalkListFragment : Fragment() {
-    private lateinit var v: View
+    private lateinit var userId: String
+    private lateinit var data: ArrayList<RoomWithImageUrlAndLatestTalk>
+    private var adapter: RoomAdapterWithImage? = null
     private var alive = true
+    private var first = true
+    // localDB
+    private lateinit var fdb: SQLiteDatabase
+    private lateinit var friendHelper: FriendDBHelper
+    private lateinit var rdb: SQLiteDatabase
+    private lateinit var roomHelper: RoomDBHelper
+    private lateinit var tdb: SQLiteDatabase
+    private lateinit var talkHelper: TalkDBHelper
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        if (USE_LOCAL_DB) {
+            try {
+                friendHelper = FriendDBHelper(context)
+                roomHelper = RoomDBHelper(context)
+                talkHelper = TalkDBHelper(context)
+            } catch (e: SQLiteException) {
+                debugLog(context, "helper error: ${e.toString()}")
+            }
+
+            try {
+                fdb = friendHelper.writableDatabase
+                rdb = roomHelper.writableDatabase
+                tdb = talkHelper.writableDatabase
+                Toast.makeText(context, "accessed to database", Toast.LENGTH_SHORT).show()
+            } catch (e: SQLiteException) {
+                debugLog(context, "writable error: ${e.toString()}")
+            }
+        } else {
+            context!!.deleteDatabase(FriendDBHelper(context).databaseName)
+            context!!.deleteDatabase(RoomDBHelper(context).databaseName)
+            context!!.deleteDatabase(TalkDBHelper(context).databaseName)
+        }
+
+        // MyPagerAdapterで設定しておいたargumentsを取得
+        userId = arguments!!.getString("userId")
+        data = ArrayList()
+        adapter = RoomAdapterWithImage(context!!, data)
+        if(USE_LOCAL_DB) {
+            getRoomByLocalDB()
+            Collections.sort(data, RoomComparator())
+        }
+    }
+
+    private lateinit var v: View
+    private lateinit var roomList: ListView
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
         // Inflate the layout for this fragment
         v = inflater.inflate(R.layout.fragment_talk_list, container, false)
 
-        //MyPagerAdapterで設定しておいたargumentsを取得
-        userId = arguments!!.getString("userId")
         roomList = v.findViewById(R.id.roomListView) as ListView
 
-        data = ArrayList()
-        adapter = RoomAdapterWithImage(context!!, data)
         roomList.setAdapter(adapter)
-
-        getRoom(userId)
 
         roomList.setOnItemClickListener { _, _, position, _ ->
             val roomId: String = data[position].roomId
@@ -58,20 +102,84 @@ class TalkListFragment : Fragment() {
         return v
     }
 
+    private lateinit var timer: TimerTask
+
+    override fun onResume() { // Fragment間の遷移のときは，呼ばれない！！
+        super.onResume()
+        alive = true
+        first = true
+        timer = Timer().schedule(0, 500000, { getRoom(userId) })
+    }
+
+    override fun onPause() {
+        super.onPause()
+        alive = false
+        timer.cancel()
+    }
+
+    private fun getRoomByLocalDB() {
+        adapter?.clear() // 空にする
+        RoomLocalDBService().getAllRoom(rdb, context) {
+            println("**************************")
+            println("room number: ${it.count}")
+            println("add room; roomId = ${it.getString(0)}\n")
+            adapter?.add(RoomWithImageUrlAndLatestTalk(
+                    it.getString(0),
+                    it.getString(1),
+                    it.getString(2),
+                    it.getString(6),
+                    Timestamp.valueOf(it.getString(3)),
+                    it.getLong(5),
+                    Timestamp.valueOf(it.getString(7))
+            ))
+        }
+        adapter?.notifyDataSetChanged()
+    }
+
+    // userが所属するroomを取得
     private fun getRoom(userId: String) {
         roomService.getRoomsByUserId(userId)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
-                    // Toast.makeText(context, "get room succeeded", Toast.LENGTH_SHORT).show()
-                    // println("get room succeeded: $it")
+                    print("room number: " + it.size)
                     for(r in it) {
-                        getLatestTalkWithLongPolling(r.roomId, -1)
+                        var target = searchDataWithRoomId(r.roomId)
+                        if(target == null) { // ルームがまだ存在していない場合
+                            if(USE_LOCAL_DB)
+                                getLatestTalkWithLongPolling(r.roomId, getSinceTalkIdByLocalDB(r.roomId))
+                            else
+                                getLatestTalkWithLongPolling(r.roomId, -1)
+                        } else {
+                            if(first)
+                                getLatestTalkWithLongPolling(r.roomId, getSinceTalkIdByData(r.roomId))
+                        }
                     }
+                    if(first)
+                        first = false
                 }, {
-                    Toast.makeText(context, "get room failed: $it", Toast.LENGTH_LONG).show()
-                    println("get room failed: $it")
+                    debugLog(context, "get room failed: $it")
                 })
+    }
+
+    private fun getSinceTalkIdByData(roomId: String): Long {
+        val target = data.find { it.roomId == roomId }
+        if(target != null)
+            return target.sinceTalkId
+        else
+            return -1
+    }
+
+    private fun getSinceTalkIdByLocalDB(roomId: String): Long {
+        val sqlstr = "select * from rooms where room_id = '${roomId}'"
+        val cursor = rdb.rawQuery(sqlstr, null)
+        cursor.moveToPosition(-1)
+        try {
+            cursor.moveToNext()
+            return cursor.getLong(5)
+        } catch(e: CursorIndexOutOfBoundsException) {
+            return -1
+        }
     }
 
     private fun getLatestTalkWithLongPolling(roomId: String, sinceTalkId: Long) {
@@ -79,95 +187,160 @@ class TalkListFragment : Fragment() {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
-                    //Toast.makeText(this, "get talk succeeded", Toast.LENGTH_SHORT).show()
-                    // println("get talk succeeded: $it")
-
-                    if (!it.isEmpty()) {
+                    if (!it.isEmpty()) { // 新着メッセージがある場合
                         var target = searchDataWithRoomId(roomId)
-                        if(target != null) {
+                        if(target != null) { // ルームがすでに存在している場合
                             target.latestTalk = it.last().text
                             target.latestTalkTime = it.last().createdAt
-                            adapter?.notifyDataSetChanged()
+                            target.sinceTalkId = it.last().talkId
                             Collections.sort(data, RoomComparator())
-                        } else {
+                            adapter?.notifyDataSetChanged()
+
+                            if(USE_LOCAL_DB)
+                                updateRoomLocalDB(roomId, it.last().talkId, it.last().text, it.last().createdAt)
+                        } else { // ルームがまだ存在していない場合，新規追加
                             getRoomNameAndIcon(RoomWithImageUrlAndLatestTalk(
                                     roomId,
                                     "hoge",
                                     "default.jpg",
                                     it.last().text,
-                                    it.last().createdAt
-                            ))
+                                    it.last().createdAt,
+                                    it.last().talkId
+                            ),  it.last().talkId)
                         }
+                        if(USE_LOCAL_DB)
+                            updateTalkLocalDB(it)
                         if(alive)
                             getLatestTalkWithLongPolling(roomId, it.last().talkId)
-                    } else {
+                    } else { // 新着メッセージがない場合
+                        var target = searchDataWithRoomId(roomId)
+                        if(target == null) { // ルームがまだ存在していない場合，新規追加
+                            getRoomNameAndIcon(RoomWithImageUrlAndLatestTalk(
+                                    roomId,
+                                    "hoge",
+                                    "default.jpg",
+                                    "",
+                                    Timestamp(0L)
+                            ))
+                        }
                         if(alive)
                             getLatestTalkWithLongPolling(roomId, sinceTalkId)
                     }
                 }, {
-                    Toast.makeText(context, "get talk failed: $it", Toast.LENGTH_SHORT).show()
-                    println("get talk failed: $it")
+                    debugLog(context, "get talk failed: $it")
                     if(alive)
                         getLatestTalkWithLongPolling(roomId, sinceTalkId)
+                    return@subscribe // このスレッドは終了
                 })
     }
 
+    // （ローカルに存在する）ルームの検索
     private fun searchDataWithRoomId(roomId: String): RoomWithImageUrlAndLatestTalk? {
         val target = data.find { it.roomId == roomId }
         return target
     }
 
-    private fun getRoomNameAndIcon(roomWithImageUrlAndLatestTalk: RoomWithImageUrlAndLatestTalk) {
+    private fun getRoomNameAndIcon(roomWithImageUrlAndLatestTalk: RoomWithImageUrlAndLatestTalk, sinceTalkId: Long = -1) {
+        roomService.getRoomByRoomId(roomWithImageUrlAndLatestTalk.roomId)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                    if(it.isGroup) { // グループ
+                        roomWithImageUrlAndLatestTalk.createdAt = it.createdAt
+                        roomWithImageUrlAndLatestTalk.roomName = it.roomName
+                        roomWithImageUrlAndLatestTalk.pathToFile = "default.jpg"
+                        print("(1) add room; roomId = ${roomWithImageUrlAndLatestTalk.roomId}\n")
+                        adapter?.add(roomWithImageUrlAndLatestTalk)
+                        Collections.sort(data, RoomComparator())
+
+                        if(USE_LOCAL_DB) {
+                            RoomLocalDBService().addRoom(it.roomId,
+                                    it.roomName,
+                                    "default.jpg",
+                                    it.createdAt,
+                                    it.isGroup,
+                                    sinceTalkId,
+                                    roomWithImageUrlAndLatestTalk.latestTalk,
+                                    roomWithImageUrlAndLatestTalk.latestTalkTime,
+                                    rdb, context)
+                            debugLog(context, "added room to localDB: roomid is ${it.roomId}")
+                        }
+                    } else { // 個人チャット
+                        getMembers(roomWithImageUrlAndLatestTalk, sinceTalkId)
+                    }
+                }, {
+                    debugLog(context, "get room failed: $it")
+                })
+    }
+
+    private fun updateRoomLocalDB(roomId: String,
+                                  sinceTalkId: Long,
+                                  latestTalk: String,
+                                  latestTalkTime: Timestamp) {
+        RoomLocalDBService().updateSinceTalkId(roomId, sinceTalkId, latestTalk, latestTalkTime, rdb, context)
+    }
+
+    private fun updateTalkLocalDB(talks: List<Talk>) {
+        for(t in talks) {
+            TalkLocalDBService().addTalk(t, tdb, context)
+        }
+    }
+
+    private fun addMembersToLocalDB(roomId: String, userIds: ArrayList<String>) {
+        RoomLocalDBService().addRoomMembers(roomId, userIds, rdb, context)
+    }
+
+    private fun getMembers(roomWithImageUrlAndLatestTalk: RoomWithImageUrlAndLatestTalk, sinceTalkId: Long) {
         roomService.getRoomMembersByRoomId(roomWithImageUrlAndLatestTalk.roomId)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
-                    // Toast.makeText(context, "get room succeeded", Toast.LENGTH_SHORT).show()
-                    // println("get room succeeded: $it")
-                    if(it.size == 2){ // 個人チャット
-                        val friendId = it.find { !it.uid.equals(userId) }?.uid
-                        if(friendId == null) { // 自分が二人の個人チャット（本来ありえない）
-                            // getFriendNameAndIcon(roomWithImageUrlAndLatestTalk, userId)
-                        } else {
-                            getFriendNameAndIcon(roomWithImageUrlAndLatestTalk, friendId)
-                        }
-                    } else { // 数で判別すると，2人のグループのときにバグりそう．roomにisGroupなどのフラグをたてるのかなあ．
-                        // TODO
+                    val friendId = it.find { !it.uid.equals(userId) }?.uid
+                    if(friendId != null) {
+                        getFriendNameAndIcon(roomWithImageUrlAndLatestTalk, friendId, sinceTalkId)
+                    } else { // 自分とフレンドになってしまった場合（普通ありえない）
                     }
                 }, {
-                    Toast.makeText(context, "get room failed: $it", Toast.LENGTH_LONG).show()
-                    println("get room failed: $it")
+                    debugLog(context, "get room members failed: $it")
                 })
     }
 
-    private fun getFriendNameAndIcon(roomWithImageUrlAndLatestTalk: RoomWithImageUrlAndLatestTalk, friendId: String) {
+    private fun getFriendNameAndIcon(roomWithImageUrlAndLatestTalk: RoomWithImageUrlAndLatestTalk, friendId: String, sinceTalkId: Long) {
         userProfileService.getUserById(friendId)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
-                    // Toast.makeText(this, "get talk succeeded", Toast.LENGTH_SHORT).show()
-                    println("get name succeeded: $it")
                     roomWithImageUrlAndLatestTalk.roomName = it.name
-                    getFriendIcon(roomWithImageUrlAndLatestTalk, friendId)
+                    getFriendIcon(roomWithImageUrlAndLatestTalk, friendId, sinceTalkId)
                 }, {
-                    // Toast.makeText(this, "get name failed: $it", Toast.LENGTH_SHORT).show()
-                    println("get name failed: $it")
+                    debugLog(context, "get name failed: $it")
                 })
     }
 
-    private fun getFriendIcon(roomWithImageUrlAndLatestTalk: RoomWithImageUrlAndLatestTalk, friendId: String) {
+    private fun getFriendIcon(roomWithImageUrlAndLatestTalk: RoomWithImageUrlAndLatestTalk, friendId: String, sinceTalkId: Long) {
         imageService.getImageUrlById(friendId)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
-                    // Toast.makeText(this, "get image url succeeded", Toast.LENGTH_SHORT).show()
-                    println("get image url succeeded: $it")
                     roomWithImageUrlAndLatestTalk.pathToFile = it.pathToFile
+                    print("(2) add room; roomId = ${roomWithImageUrlAndLatestTalk.roomId}\n")
                     adapter?.add(roomWithImageUrlAndLatestTalk)
                     Collections.sort(data, RoomComparator())
+
+                    if(USE_LOCAL_DB) {
+                        RoomLocalDBService().addRoom(roomWithImageUrlAndLatestTalk.roomId,
+                                roomWithImageUrlAndLatestTalk.roomName,
+                                roomWithImageUrlAndLatestTalk.pathToFile,
+                                roomWithImageUrlAndLatestTalk.createdAt,
+                                false,
+                                sinceTalkId,
+                                roomWithImageUrlAndLatestTalk.latestTalk,
+                                roomWithImageUrlAndLatestTalk.latestTalkTime,
+                                rdb, context)
+                        addMembersToLocalDB(roomWithImageUrlAndLatestTalk.roomId, arrayListOf(userId, friendId))
+                    }
                 }, {
-                    // Toast.makeText(this, "get image url failed: $it", Toast.LENGTH_SHORT).show()
-                    println("get image url failed: $it")
+                    debugLog(context, "get image url failed: $it")
                 })
     }
 

--- a/app/src/main/java/intern/line/tokyoaclient/Fragment/TalkListFragment.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/Fragment/TalkListFragment.kt
@@ -1,4 +1,4 @@
-package intern.line.tokyoaclient
+package intern.line.tokyoaclient.Fragment
 
 
 import android.content.Intent
@@ -8,13 +8,16 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ListView
-import android.widget.TextView
 import android.widget.Toast
+import intern.line.tokyoaclient.Adapter.RoomAdapterWithImage
+import intern.line.tokyoaclient.Adapter.RoomComparator
 import intern.line.tokyoaclient.HttpConnection.imageService
 import intern.line.tokyoaclient.HttpConnection.model.RoomWithImageUrlAndLatestTalk
 import intern.line.tokyoaclient.HttpConnection.roomService
 import intern.line.tokyoaclient.HttpConnection.talkService
 import intern.line.tokyoaclient.HttpConnection.userProfileService
+import intern.line.tokyoaclient.R
+import intern.line.tokyoaclient.TalkActivity
 import rx.android.schedulers.AndroidSchedulers
 import rx.schedulers.Schedulers
 import java.util.*
@@ -47,7 +50,7 @@ class TalkListFragment : Fragment() {
 
         getRoom(userId)
 
-        roomList.setOnItemClickListener { adapterView, view, position, id ->
+        roomList.setOnItemClickListener { _, _, position, _ ->
             val roomId: String = data[position].roomId
             goToTalk(roomId, data[position].roomName)
         }

--- a/app/src/main/java/intern/line/tokyoaclient/FriendListActivity.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/FriendListActivity.kt
@@ -4,9 +4,11 @@ import android.content.Intent
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.widget.*
+import intern.line.tokyoaclient.Adapter.UserListAdapter
 import intern.line.tokyoaclient.HttpConnection.*
 import rx.android.schedulers.AndroidSchedulers
 import intern.line.tokyoaclient.HttpConnection.friendService
+import kotlinx.android.synthetic.main.fragment_friend_list.*
 import rx.schedulers.Schedulers
 import java.util.UUID
 
@@ -15,6 +17,7 @@ class FriendListActivity : AppCompatActivity() {
 
     private lateinit var friendList: ListView
     private lateinit var addFriendButton: Button
+    private lateinit var createGroupButton: Button
     private var adapter: UserListAdapter? = null
 
     private lateinit var userId: String
@@ -25,6 +28,7 @@ class FriendListActivity : AppCompatActivity() {
 
         userId = intent.getStringExtra("userId")
         addFriendButton = findViewById(R.id.addFriendButton) as Button
+        createGroupButton = findViewById(R.id.createGroupButton) as Button
         friendList = findViewById(R.id.friendList) as ListView
 
         adapter = UserListAdapter(this, ArrayList())
@@ -36,7 +40,10 @@ class FriendListActivity : AppCompatActivity() {
         addFriendButton.setOnClickListener {
             goToAddFriend(userId)
         }
-        friendList.setOnItemClickListener { adapterView, view, position, id ->
+        createGroupButton.setOnClickListener {
+            goToCreateGroup(userId)
+        }
+        friendList.setOnItemClickListener { _, view, _, _ ->
             val friendId = view.findViewById<TextView>(R.id.idTextView).text.toString()
             val num1: Int = Math.abs(UUID.nameUUIDFromBytes(userId.toByteArray()).hashCode())
             val num2: Int = Math.abs(UUID.nameUUIDFromBytes(friendId.toByteArray()).hashCode())
@@ -92,6 +99,12 @@ class FriendListActivity : AppCompatActivity() {
 
     private fun goToAddFriend(userId: String) {
         val intent = Intent(this, AddFriendActivity::class.java)
+        intent.putExtra("userId", userId)
+        startActivity(intent)
+    }
+
+    private fun goToCreateGroup(userId: String) {
+        val intent = Intent(this, CreateGroupActivity::class.java)
         intent.putExtra("userId", userId)
         startActivity(intent)
     }

--- a/app/src/main/java/intern/line/tokyoaclient/HttpConnection/model/entities.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/HttpConnection/model/entities.kt
@@ -38,7 +38,8 @@ data class Room(
         var roomId: String = "room0",
         var roomName: String = "default",
         var createdAt: Timestamp = Timestamp(0L),
-        var updatedAt: Timestamp = Timestamp(0L)
+        var updatedAt: Timestamp = Timestamp(0L),
+        var isGroup: Boolean = false
 )
 
 data class RoomMember(
@@ -70,5 +71,7 @@ data class RoomWithImageUrlAndLatestTalk(
         var roomName: String = "default",
         var pathToFile: String,
         var latestTalk: String = "hoge",
-        var latestTalkTime: Timestamp = Timestamp(0L)
+        var latestTalkTime: Timestamp = Timestamp(0L),
+        var sinceTalkId: Long = -1,
+        var createdAt: Timestamp = Timestamp(0L)
 )

--- a/app/src/main/java/intern/line/tokyoaclient/HttpConnection/service/RoomService.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/HttpConnection/service/RoomService.kt
@@ -12,10 +12,13 @@ interface RoomService {
     fun getAllRoom(): Single<List<Room>>
 
     @GET("/room/room_id/{room_id}")
-    fun findByRoomId(@Path("room_id") roomId: String): Single<Room>
+    fun getRoomByRoomId(@Path("room_id") roomId: String): Single<Room>
 
     @POST("/room/create/{room_id}/{room_name}")
     fun addRoom(@Path("room_id") roomId: String, @Path("room_name") roomName: String): Completable
+
+    @POST("/room/create_group/{room_id}/{room_name}")
+    fun addRoomAsGroup(@Path("room_id") roomId: String, @Path("room_name") roomName: String): Completable
 
     @PUT("/room/modify/{room_id}/{room_name}")
     fun modifyroom(@Path("room_id") roomId: String, @Path("room_name") roomName: String): Completable

--- a/app/src/main/java/intern/line/tokyoaclient/LocalDataBase/LocalDBHelper.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/LocalDataBase/LocalDBHelper.kt
@@ -1,9 +1,63 @@
 package intern.line.tokyoaclient.LocalDataBase
 
+import android.content.ContentValues
 import android.content.Context
+import android.database.Cursor
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
 import android.widget.Toast
+import intern.line.tokyoaclient.HttpConnection.model.Talk
+import intern.line.tokyoaclient.debugLog
+import java.sql.Timestamp
+
+
+class SelfInfoDBHelper(var context: Context?) : SQLiteOpenHelper(context, "self_info.db", null, 1) {
+    override fun onCreate(db: SQLiteDatabase?) {
+        db?.execSQL("create table info ( " +
+                "id text not null, " +
+                "name text not null, " +
+                "path_to_file text not null" +
+                ");")
+    }
+
+    override fun onUpgrade(db: SQLiteDatabase?, oldVersion: Int, newVersion: Int) {
+        //バージョンアップしたときに実行される
+        //テーブルのdeleteなどを行う
+        db?.execSQL("drop table if exists info")
+        onCreate(db)
+        Toast.makeText(context, "table updated", Toast.LENGTH_SHORT).show()
+    }
+}
+
+class SelfInfoLocalDBService {
+    fun addInfo(id: String, name: String, pathToFile: String, sdb: SQLiteDatabase, context: Context?) {
+        val value: ContentValues = ContentValues().also {
+            it.put("id", id)
+            it.put("name", name)
+            it.put("path_to_file", pathToFile)
+        }
+        val res: Long = sdb.insert("info", null, value)
+        if(res < 0) {
+            // error
+            Toast.makeText(context, "error in INSERT", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    fun getInfo(sdb: SQLiteDatabase, func: (Cursor) -> Unit) {
+        val sqlstr = "select * from info"
+        val cursor = sdb.rawQuery(sqlstr, null)
+        cursor.moveToPosition(-1)
+        func(cursor)
+    }
+
+    fun updateInfo(id: String, name: String, pathToFile: String, sdb: SQLiteDatabase) {
+        val value: ContentValues = ContentValues().also {
+            it.put("name", name)
+            it.put("path_to_file", pathToFile)
+        }
+        sdb.update("info", value, "id=?", arrayOf(id))
+    }
+}
 
 
 class TalkDBHelper(var context: Context?) : SQLiteOpenHelper(context, "talk_info.db", null, 1) {
@@ -30,17 +84,52 @@ class TalkDBHelper(var context: Context?) : SQLiteOpenHelper(context, "talk_info
     }
 }
 
+class TalkLocalDBService {
+    fun getTalkByRoomId(roomId: String, tdb: SQLiteDatabase, context: Context?, func: (Cursor) -> Unit) {
+        val sqlstr = "select * from talks where room_id = '$roomId'"
+        val cursor = tdb.rawQuery(sqlstr, null)
+        cursor.moveToPosition(-1)
+        while(cursor.moveToNext()) {
+            func(cursor)
+        }
+    }
+
+    fun getTalkByTalkId(talkId: Long, tdb: SQLiteDatabase, func: (Cursor) -> Unit) {
+        val sqlstr = "select * from talks where talk_id = '$talkId'"
+        val cursor = tdb.rawQuery(sqlstr, null)
+        cursor.moveToPosition(-1)
+        func(cursor)
+    }
+
+    fun addTalk(talk: Talk, tdb: SQLiteDatabase, context: Context?) {
+        getTalkByTalkId(talk.talkId, tdb) {
+            if(it.count == 0) { // 見つからなければ，addする
+                val value: ContentValues = ContentValues().also {
+                    it.put("talk_id", talk.talkId)
+                    it.put("sender_id", talk.senderId)
+                    it.put("room_id", talk.roomId)
+                    it.put("content", talk.text)
+                    it.put("num_read", talk.numRead)
+                    it.put("created_at", talk.createdAt.toString())
+                    it.put("updated_at", talk.updatedAt.toString())
+                }
+                val res: Long = tdb.insert("talks", null, value)
+                // debugLog(context, "INSERTed talk_id: $talk.talkId")
+                if(res < 0) {
+                    // error
+                    Toast.makeText(context, "error in INSERT", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+}
+
 class FriendDBHelper(var context: Context?) : SQLiteOpenHelper(context, "friend_info.db", null, 1) {
     override fun onCreate(db: SQLiteDatabase?) {
         //データベースがないときに実行される
         // フレンド
         // 初期およびフレンド追加時以外は変化しないはず？
         db?.execSQL("create table friends ( " +
-                "friend_id text not null " +
-                ");")
-        // フレンド名
-        // フレンドがユーザ名を変更した時に差分が出てしまう
-        db?.execSQL("create table friend_data ( " +
                 "id text not null, " +
                 "name text not null, " +
                 "path_to_file text not null" +
@@ -52,10 +141,160 @@ class FriendDBHelper(var context: Context?) : SQLiteOpenHelper(context, "friend_
     override fun onUpgrade(db: SQLiteDatabase?, oldVersion: Int, newVersion: Int) {
         //バージョンアップしたときに実行される
         //テーブルのdeleteなどを行う
-        // TODO: バージョンアップ時の挙動
         db?.execSQL("drop table if exists friends")
-        db?.execSQL("drop table if exists friend_data")
         onCreate(db)
         Toast.makeText(context, "table updated", Toast.LENGTH_SHORT).show()
+    }
+}
+
+class FriendLocalDBService {
+    fun addFriend(id: String, name: String, pathToFile: String, fdb: SQLiteDatabase, context: Context?) {
+        val value: ContentValues = ContentValues().also {
+            it.put("id", id)
+            it.put("name", name)
+            it.put("path_to_file", pathToFile)
+        }
+        val res: Long = fdb.insert("friends", null, value)
+        if(res < 0) {
+            // error
+            Toast.makeText(context, "error in INSERT", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    fun getAllFriend(fdb: SQLiteDatabase, context: Context?, func: (Cursor) -> Unit) {
+        val sqlstr = "select * from friends"
+        val cursor = fdb.rawQuery(sqlstr, null)
+        cursor.moveToPosition(-1)
+        while(cursor.moveToNext()) {
+            func(cursor)
+        }
+    }
+
+    fun getFriend(id: String, fdb: SQLiteDatabase, context: Context?, func: (Cursor) -> Unit) {
+        val sqlstr = "select * from friends where id = '$id'"
+        val cursor = fdb.rawQuery(sqlstr, null)
+        cursor.moveToPosition(-1)
+        func(cursor)
+    }
+}
+
+class RoomDBHelper(var context: Context?) : SQLiteOpenHelper(context, "room_info.db", null, 1) {
+    override fun onCreate(db: SQLiteDatabase?) {
+        //データベースがないときに実行される
+        //
+        db?.execSQL("create table rooms ( " +
+                "room_id text not null, " +
+                "room_name text not null, " +
+                "path_to_file text not null, " +
+                "created_at text not null, " +
+                "is_group integer not null, " +
+                "since_talk_id integer not null, " +
+                "latest_talk text not null, " +
+                "latest_talk_time text not null" +
+                ");")
+        //
+        db?.execSQL("create table room_members ( " +
+                "room_id text not null, " +
+                "user_id text not null" +
+                ");")
+
+        Toast.makeText(context, "table created", Toast.LENGTH_SHORT).show()
+    }
+
+    override fun onUpgrade(db: SQLiteDatabase?, oldVersion: Int, newVersion: Int) {
+        //バージョンアップしたときに実行される
+        //テーブルのdeleteなどを行う
+        // TODO: バージョンアップ時の挙動
+        db?.execSQL("drop table if exists rooms")
+        db?.execSQL("drop table if exists room_members")
+        onCreate(db)
+        Toast.makeText(context, "table updated", Toast.LENGTH_SHORT).show()
+    }
+}
+
+class RoomLocalDBService {
+    fun addRoom(id: String,
+                name: String,
+                pathToFile: String,
+                createdAt: Timestamp,
+                isGroup: Boolean,
+                sinceTalkId: Long,
+                latestTalk: String,
+                latestTalkTime: Timestamp,
+                rdb: SQLiteDatabase, context: Context?) {
+        getRoomById(id, rdb, context) {
+            if(it.count == 0) {
+                val value: ContentValues = ContentValues().also {
+                    it.put("room_id", id)
+                    it.put("room_name", name)
+                    it.put("path_to_file", pathToFile)
+                    it.put("created_at", createdAt.toString())
+                    it.put("is_group", if(isGroup) 1 else 0)
+                    it.put("since_talk_id", sinceTalkId)
+                    it.put("latest_talk", latestTalk)
+                    it.put("latest_talk_time", latestTalkTime.toString())
+                }
+                val res: Long = rdb.insert("rooms", null, value)
+                if(res < 0) {
+                    // error
+                    Toast.makeText(context, "error in INSERT", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    fun getAllRoom(rdb: SQLiteDatabase, context: Context?, func: (Cursor) -> Unit) {
+        val sqlstr = "select * from rooms"
+        val cursor = rdb.rawQuery(sqlstr, null)
+        cursor.moveToPosition(-1)
+        while(cursor.moveToNext()) {
+            func(cursor)
+        }
+    }
+
+    fun getRoomById(id: String, rdb: SQLiteDatabase, context: Context?, func: (Cursor) -> Unit) {
+        val sqlstr = "select * from rooms where room_id = '$id'"
+        val cursor = rdb.rawQuery(sqlstr, null)
+        cursor.moveToPosition(-1)
+        func(cursor)
+    }
+
+    fun getRoomMembers(id: String, rdb: SQLiteDatabase, context: Context?, func: (Cursor) -> Unit) {
+        val sqlstr = "select * from room_members where room_id = '$id'"
+        val cursor = rdb.rawQuery(sqlstr, null)
+        cursor.moveToPosition(-1)
+        func(cursor)
+    }
+
+    fun addRoomMembers(roomId: String, userIds: ArrayList<String>, rdb: SQLiteDatabase, context: Context?) {
+        for(u in userIds) {
+            val value: ContentValues = ContentValues().also {
+                it.put("room_id", roomId)
+                it.put("user_id", u)
+            }
+            val res: Long = rdb.insert("room_members", null, value)
+            if (res < 0) {
+                // error
+                Toast.makeText(context, "error in INSERT", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    fun updateSinceTalkId(latestTalk: Talk, rdb: SQLiteDatabase, context: Context?) {
+        val value: ContentValues = ContentValues().also {
+            it.put("since_talk_id", latestTalk.talkId)
+            it.put("latest_talk", latestTalk.text)
+            it.put("latest_talk_time", latestTalk.createdAt.toString())
+        }
+        rdb.update("rooms", value, "room_id=?", arrayOf(latestTalk.roomId))
+    }
+
+    fun updateSinceTalkId(roomId: String, sinceTalkId: Long, latestTalk: String, latestTalkTime: Timestamp, rdb: SQLiteDatabase, context: Context?) {
+        val value: ContentValues = ContentValues().also {
+            it.put("since_talk_id", sinceTalkId)
+            it.put("latest_talk", latestTalk)
+            it.put("latest_talk_time", latestTalkTime.toString())
+        }
+        rdb.update("rooms", value, "room_id=?", arrayOf(roomId))
     }
 }

--- a/app/src/main/java/intern/line/tokyoaclient/MainActivity.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/MainActivity.kt
@@ -16,7 +16,7 @@ import rx.android.schedulers.AndroidSchedulers
 import rx.schedulers.Schedulers
 
 
-public val USE_LOCAL_DB = false
+public var USE_LOCAL_DB = false
 
 class MainActivity : AppCompatActivity() {
     //firabaseauthオブジェクトとログインユーザーオブジェクトのインスタンスを作っておく
@@ -38,7 +38,6 @@ class MainActivity : AppCompatActivity() {
         //ボタンをゲットしておく
         val signUpButton = findViewById(R.id.signup) as Button
         val signInButton = findViewById(R.id.signin) as Button
-        val goButton = findViewById(R.id.goButton) as Button
 
         //それぞれのボタンが押されたときにメソッドを呼び出す
         signUpButton.setOnClickListener {
@@ -47,9 +46,12 @@ class MainActivity : AppCompatActivity() {
         signInButton.setOnClickListener {
             signIn()
         }
-        goButton.setOnClickListener {
-            // goTest()
-            golocalDBTest()
+
+        findViewById<Button>(R.id.localDBButton).setOnClickListener {
+            USE_LOCAL_DB = true
+        }
+        findViewById<Button>(R.id.noLocalDBButton).setOnClickListener {
+            USE_LOCAL_DB = false
         }
     }
 

--- a/app/src/main/java/intern/line/tokyoaclient/TabLayoutActivity.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/TabLayoutActivity.kt
@@ -2,6 +2,7 @@ package intern.line.tokyoaclient
 
 import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
+import intern.line.tokyoaclient.Adapter.MyPagerAdapter
 import kotlinx.android.synthetic.main.activity_tab_layout.*
 
 class TabLayoutActivity : AppCompatActivity() {

--- a/app/src/main/java/intern/line/tokyoaclient/TalkActivity.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/TalkActivity.kt
@@ -4,12 +4,12 @@ import android.content.Context
 import android.os.Bundle
 import android.support.constraint.ConstraintLayout
 import android.support.v7.app.AppCompatActivity
-import android.util.EventLog
 import android.view.KeyEvent
 import android.view.MotionEvent
-import android.view.View
 import android.view.inputmethod.InputMethodManager
 import android.widget.*
+import intern.line.tokyoaclient.Adapter.TalkAdapter
+import intern.line.tokyoaclient.Adapter.TimeComparator
 import kotlinx.android.synthetic.main.activity_talk_page.*
 import rx.android.schedulers.AndroidSchedulers
 import rx.schedulers.Schedulers
@@ -20,7 +20,6 @@ import intern.line.tokyoaclient.HttpConnection.talkService
 import intern.line.tokyoaclient.HttpConnection.userProfileService
 import java.util.*
 import kotlin.collections.ArrayList
-import kotlin.concurrent.schedule
 
 
 class TalkActivity : AppCompatActivity() {
@@ -63,7 +62,7 @@ class TalkActivity : AppCompatActivity() {
             sendMessage()
         }
 
-        talkList.setOnItemClickListener { adapterView, view, position, id ->
+        talkList.setOnItemClickListener { _, _, _, _ ->
             focusOnBackground()
         }
 

--- a/app/src/main/java/intern/line/tokyoaclient/TalkActivity.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/TalkActivity.kt
@@ -1,6 +1,9 @@
 package intern.line.tokyoaclient
 
 import android.content.Context
+import android.database.CursorIndexOutOfBoundsException
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteException
 import android.os.Bundle
 import android.support.constraint.ConstraintLayout
 import android.support.v7.app.AppCompatActivity
@@ -16,8 +19,11 @@ import rx.schedulers.Schedulers
 import intern.line.tokyoaclient.HttpConnection.imageService
 import intern.line.tokyoaclient.HttpConnection.model.Talk
 import intern.line.tokyoaclient.HttpConnection.model.TalkWithImageUrl
+import intern.line.tokyoaclient.HttpConnection.model.UserProfileWithImageUrl
 import intern.line.tokyoaclient.HttpConnection.talkService
 import intern.line.tokyoaclient.HttpConnection.userProfileService
+import intern.line.tokyoaclient.LocalDataBase.*
+import java.sql.Timestamp
 import java.util.*
 import kotlin.collections.ArrayList
 
@@ -29,7 +35,6 @@ class TalkActivity : AppCompatActivity() {
     private var sinceTalkId: Long = -1
     private lateinit var talkList: ListView
     private var adapter: TalkAdapter? = null
-    private lateinit var timer: TimerTask
     private lateinit var data: ArrayList<TalkWithImageUrl>
     private var alive = true
 
@@ -37,15 +42,49 @@ class TalkActivity : AppCompatActivity() {
     private lateinit var inputMethodManager: InputMethodManager
     // 背景のレイアウト
     private lateinit var mainLayout: ConstraintLayout
+    // localDB
+    private lateinit var fdb: SQLiteDatabase
+    private lateinit var friendHelper: FriendDBHelper
+    private lateinit var rdb: SQLiteDatabase
+    private lateinit var roomHelper: RoomDBHelper
+    private lateinit var tdb: SQLiteDatabase
+    private lateinit var talkHelper: TalkDBHelper
+    private lateinit var sdb: SQLiteDatabase
+    private lateinit var selfInfoHelper: SelfInfoDBHelper
+    private var roomMemberList: ArrayList<UserProfileWithImageUrl> = ArrayList()
+
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_talk_page)
 
-        talkList = (findViewById(R.id.talkList) as ListView)
-        data = ArrayList()
-        adapter = TalkAdapter(this, data)
-        talkList.setAdapter(adapter)
+        if (USE_LOCAL_DB) {
+            try {
+                friendHelper = FriendDBHelper(this)
+                roomHelper = RoomDBHelper(this)
+                talkHelper = TalkDBHelper(this)
+                selfInfoHelper = SelfInfoDBHelper(this)
+            } catch (e: SQLiteException) {
+                Toast.makeText(this, "helper error: ${e.toString()}", Toast.LENGTH_SHORT).show()
+                println("helper error: ${e.toString()}")
+            }
+
+            try {
+                fdb = friendHelper.writableDatabase
+                rdb = roomHelper.writableDatabase
+                tdb = talkHelper.writableDatabase
+                sdb = selfInfoHelper.readableDatabase
+                Toast.makeText(this, "accessed to database", Toast.LENGTH_SHORT).show()
+            } catch (e: SQLiteException) {
+                Toast.makeText(this, "writable error: ${e.toString()}", Toast.LENGTH_SHORT).show()
+                println("writable error: ${e.toString()}")
+            }
+        } else {
+            this.deleteDatabase(FriendDBHelper(this).databaseName)
+            this.deleteDatabase(RoomDBHelper(this).databaseName)
+            this.deleteDatabase(TalkDBHelper(this).databaseName)
+            this.deleteDatabase(SelfInfoDBHelper(this).databaseName)
+        }
 
         (findViewById(R.id.roomName) as TextView).text = intent.getStringExtra("roomName")
         userId = intent.getStringExtra("userId")
@@ -53,6 +92,26 @@ class TalkActivity : AppCompatActivity() {
 
         inputMethodManager = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
         mainLayout = findViewById(R.id.main_layout) as ConstraintLayout
+
+        if(USE_LOCAL_DB) { // 使うユーザの情報を確保しておく
+            RoomLocalDBService().getRoomMembers(roomId, rdb, this) {
+                while(it.moveToNext()) {
+                    FriendLocalDBService().getFriend(it.getString(1), fdb, this) {
+                        try {
+                            it.moveToNext()
+                            roomMemberList.add(UserProfileWithImageUrl(it.getString(0), it.getString(1), it.getString(2))) // TODO: バグあり
+                        } catch (e: CursorIndexOutOfBoundsException) {
+                            // フレンドで見つからなかったらそれは自分
+                            SelfInfoLocalDBService().getInfo(sdb) {
+                                if(it.moveToNext())
+                                    roomMemberList.add(UserProfileWithImageUrl(it.getString(0), it.getString(1), it.getString(2)))
+                            }
+                        }
+                    }
+                }
+            }
+        } else { // TODO
+        }
 
         //ボタンをゲットしておく
         val sendButton = findViewById(R.id.sendButton) as Button
@@ -62,12 +121,26 @@ class TalkActivity : AppCompatActivity() {
             sendMessage()
         }
 
+        if(USE_LOCAL_DB) {
+            RoomLocalDBService().getRoomMembers(roomId, rdb, this) {
+                while (it.moveToNext())
+                    println("Room member: ${it.getString(1)}")
+            }
+        }
+
+        talkList = (findViewById(R.id.talkList) as ListView)
+        data = ArrayList()
+        adapter = TalkAdapter(this, data)
+        if(USE_LOCAL_DB) // 履歴から追加
+            getMessageByLocalDB(roomId)
+        talkList.setAdapter(adapter)
+        println("Room open sinceTalkId: $sinceTalkId")
+
+        getMessageWithLongPolling()
+
         talkList.setOnItemClickListener { _, _, _, _ ->
             focusOnBackground()
         }
-
-        // timer = Timer().schedule(0, 1000, { getMessage() })
-        getMessageWithLongPolling()
     }
 
     override fun onTouchEvent(event: MotionEvent?): Boolean {
@@ -78,7 +151,6 @@ class TalkActivity : AppCompatActivity() {
     override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
         if (keyCode == KeyEvent.KEYCODE_BACK) {
             // 戻るボタンが押されたときの処理
-            // timer.cancel()
             alive = false
         }
         return super.onKeyDown(keyCode, event)
@@ -94,61 +166,47 @@ class TalkActivity : AppCompatActivity() {
     private fun sendMessage() {
         if (inputText.text.toString() == "") {
             // do nothing
-            // inputText.error = "コメントを入れてください"
         } else {
             val input: String = inputText.text.toString()
             talkService.addTalk(userId, roomId, input)
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe({
-                        // Toast.makeText(this, "send talk succeeded", Toast.LENGTH_SHORT).show()
-                        println("send talk succeeded: $input")
                         // getMessage()
                         inputText.editableText.clear() // 入力内容をリセットする
                         adapter?.notifyDataSetChanged()
-                        // talkList.setSelection(adapter!!.count)
+                        // talkList.setSelection(adapter!!.count) // 最下部にfocusする
                     }, {
-                        // Toast.makeText(this, "send talk failed: $it", Toast.LENGTH_SHORT).show()
-                        println("send talk failed: $it")
+                        debugLog(this, "send talk failed: $it")
                     })
         }
     }
 
-    private fun getAllMessages() {
-        talkService.getAllTalk()
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe({
-                    sinceTalkId = it.last().talkId
-                    println(it.toString())
-                }, {
-
-                })
+    private fun getMessageByLocalDB(roomId: String) {
+        TalkLocalDBService().getTalkByRoomId(roomId, tdb, this) {
+            val member = findMemberFromList(roomMemberList, it.getString(1))
+            if(member != null) {
+                adapter?.add(TalkWithImageUrl(
+                        it.getLong(0),
+                        member.name,
+                        it.getString(2), // roomId
+                        it.getString(3),
+                        it.getLong(4),
+                        member.pathToFile,
+                        Timestamp.valueOf(it.getString(5)),
+                        Timestamp.valueOf(it.getString(6))))
+                Collections.sort(data, TimeComparator())
+                adapter?.notifyDataSetChanged()
+                if(sinceTalkId < it.getLong(0))
+                    sinceTalkId = it.getLong(0)
+            } else {
+                println("something wrong in find member from list")
+            }
+        }
     }
 
-    private fun getMessage() {
-        talkService.getTalk(roomId, sinceTalkId)
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe({
-                    //Toast.makeText(this, "get talk succeeded", Toast.LENGTH_SHORT).show()
-                    println("get talk succeeded: $it")
-
-                    if (!it.isEmpty()) {
-                        // println("it[0].talkId: ${it[0].talkId}")
-                        sinceTalkId = it.last().talkId
-                        // adapter.addAll(it.map { talk -> talk.text })
-                        for(t in it) {
-                            getSendersName(t)
-                        }
-                    }
-
-                    println("sinceTalkId: $sinceTalkId")
-                    adapter?.notifyDataSetChanged()
-                }, {
-                    Toast.makeText(this, "get talk failed: $it", Toast.LENGTH_SHORT).show()
-                    println("get talk failed: $it")
-                })
+    private fun findMemberFromList(data: ArrayList<UserProfileWithImageUrl>, userId: String): UserProfileWithImageUrl? {
+        return data.find { it.id.equals(userId) }
     }
 
     private fun getMessageWithLongPolling() {
@@ -161,8 +219,15 @@ class TalkActivity : AppCompatActivity() {
 
                     if (!it.isEmpty()) {
                         sinceTalkId = it.last().talkId
+                        if(USE_LOCAL_DB)
+                            RoomLocalDBService().updateSinceTalkId(it.last(), rdb, this) // 最新トークを更新
                         for(t in it) {
-                            getSendersName(t)
+                            if(USE_LOCAL_DB) {
+                                addMessageUsingMemberList(t)
+                                addMessageToLocalDB(t) // トークを更新
+                            } else {
+                                getSendersName(t)
+                            }
                         }
                     }
 
@@ -178,17 +243,45 @@ class TalkActivity : AppCompatActivity() {
                 })
     }
 
+    private fun addMessageToLocalDB(talk: Talk) {
+        TalkLocalDBService().addTalk(talk, tdb, this)
+    }
+
+    private fun addMessageUsingMemberList(talk: Talk) {
+        val member = findMemberFromList(roomMemberList, talk.senderId)
+        if (member != null) {
+            adapter?.add(TalkWithImageUrl(
+                    talk.talkId,
+                    member.name,
+                    talk.roomId,
+                    talk.text,
+                    talk.numRead,
+                    member.pathToFile,
+                    talk.createdAt,
+                    talk.updatedAt))
+        } else {
+            adapter?.add(TalkWithImageUrl(
+                    talk.talkId,
+                    "unknown",
+                    talk.roomId,
+                    talk.text,
+                    talk.numRead,
+                    "default.jpg",
+                    talk.createdAt,
+                    talk.updatedAt))
+        }
+        Collections.sort(data, TimeComparator())
+        adapter?.notifyDataSetChanged()
+    }
+
     private fun getSendersName(talk: Talk) {
         userProfileService.getUserById(talk.senderId)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
-                    //Toast.makeText(this, "get talk succeeded", Toast.LENGTH_SHORT).show()
-                    println("get name succeeded: $it")
                     getImageUrl(talk, it.name)
                 }, {
-                    // Toast.makeText(this, "get name failed: $it", Toast.LENGTH_SHORT).show()
-                    println("get name failed: $it")
+                    debugLog(this, "get name failed: $it")
                 })
     }
 
@@ -197,14 +290,11 @@ class TalkActivity : AppCompatActivity() {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({
-                    //Toast.makeText(this, "get image url succeeded", Toast.LENGTH_SHORT).show()
-                    println("get image url succeeded: $it")
                     adapter?.add(TalkWithImageUrl(talk.talkId, name, talk.roomId, talk.text, talk.numRead, it.pathToFile, talk.createdAt, talk.updatedAt))
                     Collections.sort(data, TimeComparator())
                     talkList.setSelection(adapter!!.count)
                 }, {
-                    // Toast.makeText(this, "get image url failed: $it", Toast.LENGTH_SHORT).show()
-                    println("get image url failed: $it")
+                    debugLog(this, "get image url failed: $it")
                 })
     }
 }

--- a/app/src/main/java/intern/line/tokyoaclient/Utils.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/Utils.kt
@@ -1,0 +1,10 @@
+package intern.line.tokyoaclient
+
+import android.content.Context
+import android.widget.Toast
+
+
+fun debugLog(context: Context?, str: String) {
+    Toast.makeText(context, str, Toast.LENGTH_SHORT).show()
+    println(str)
+}

--- a/app/src/main/java/intern/line/tokyoaclient/localDBDebugActivity.kt
+++ b/app/src/main/java/intern/line/tokyoaclient/localDBDebugActivity.kt
@@ -8,6 +8,7 @@ import android.widget.*
 import kotlinx.android.synthetic.main.activity_localdb_debug.*
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteException
+import intern.line.tokyoaclient.Adapter.TestDataAdapter
 import intern.line.tokyoaclient.HttpConnection.model.Talk
 import intern.line.tokyoaclient.LocalDataBase.TalkDBHelper
 import java.sql.Time

--- a/app/src/main/res/layout/activity_configure_group.xml
+++ b/app/src/main/res/layout/activity_configure_group.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <ImageView
+        android:id="@+id/groupIcon"
+        android:layout_width="120dp"
+        android:layout_height="120dp" />
+
+    <EditText
+        android:id="@+id/groupName"
+        android:layout_width="300dp"
+        android:layout_height="50dp"
+        android:textSize="20sp"
+        android:hint="グループ名"
+        app:layout_constraintStart_toEndOf="@+id/groupIcon"
+        app:layout_constraintBottom_toBottomOf="@+id/groupIcon" />
+
+    <ListView
+        android:id="@+id/groupMembers"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="120dp"
+        android:layout_marginBottom="100dp"
+        app:layout_constraintTop_toBottomOf="@+id/groupIcon" />
+
+    <Button
+        android:id="@+id/createButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:hint="作成"
+        android:layout_marginBottom="30dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_create_group.xml
+++ b/app/src/main/res/layout/activity_create_group.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <TextView
+        android:id="@+id/instructionText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="招待するフレンドの選択"
+        android:textSize="20sp"
+        android:gravity="center"
+        android:background="@color/colorPrimaryDark" />
+
+    <ListView
+        android:id="@+id/friendList"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="25dp"
+        android:layout_marginBottom="70dp"/>
+
+    <Button
+        android:id="@+id/createButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="10dp"
+        android:hint="グループ作成"
+        android:gravity="center"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+    <TextView
+        android:id="@+id/counter"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:hint="0"
+        android:layout_marginBottom="10dp"
+        android:layout_marginEnd="50dp"
+        android:layout_marginRight="50dp"
+        android:textSize="40sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_create_group.xml
+++ b/app/src/main/res/layout/activity_create_group.xml
@@ -18,7 +18,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginTop="25dp"
-        android:layout_marginBottom="70dp"/>
+        android:layout_marginBottom="70dp" />
 
     <Button
         android:id="@+id/createButton"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -92,16 +92,18 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <Button
-        android:id="@+id/goButton"
+        android:id="@+id/localDBButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="296dp"
-        android:layout_marginRight="296dp"
-        android:layout_marginTop="265dp"
-        android:text="debug"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/nameText" />
+        android:text="use localDB"
+        app:layout_constraintBottom_toTopOf="@+id/noLocalDBButton"
+        app:layout_constraintEnd_toEndOf="parent" />
 
+    <Button
+        android:id="@+id/noLocalDBButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="don't use localDB"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_friend_list.xml
+++ b/app/src/main/res/layout/fragment_friend_list.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".FriendListFragment">
+    tools:context=".Fragment.FriendListFragment">
 
     <!-- TODO: Update blank fragment layout -->
     <android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
@@ -28,7 +28,7 @@
             android:text="UserName"
             android:textSize="25sp"
             app:layout_constraintBottom_toBottomOf="@+id/icon"
-            app:layout_constraintEnd_toStartOf="@+id/addFriendButton"
+            app:layout_constraintEnd_toStartOf="@+id/createGroupButton"
             app:layout_constraintStart_toEndOf="@+id/icon"
             app:layout_constraintTop_toTopOf="@+id/icon" />
 
@@ -68,6 +68,23 @@
             android:layout_marginEnd="1dp"
             android:layout_marginRight="1dp"
             android:gravity="center_vertical|center_horizontal"
+            android:text="🔎"
+            android:textSize="24sp"
+            app:layout_constraintBottom_toTopOf="@+id/ownNameText"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toEndOf="@+id/friendListTextView"
+            app:layout_constraintTop_toBottomOf="@+id/createGroupButton"
+            app:layout_constraintVertical_bias="0.019" />
+
+        <Button
+            android:id="@+id/createGroupButton"
+            style="@style/Widget.AppCompat.Button.Small"
+            android:layout_width="50dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="1dp"
+            android:layout_marginRight="1dp"
+            android:gravity="center_vertical|center_horizontal"
             android:text="+"
             android:textSize="24sp"
             app:layout_constraintBottom_toTopOf="@+id/ownNameText"
@@ -76,6 +93,7 @@
             app:layout_constraintStart_toEndOf="@+id/friendListTextView"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintVertical_bias="0.019" />
+
     </android.support.constraint.ConstraintLayout>
 
 

--- a/app/src/main/res/layout/fragment_friend_list.xml
+++ b/app/src/main/res/layout/fragment_friend_list.xml
@@ -34,30 +34,57 @@
 
         <TextView
             android:id="@+id/friendListTextView"
-            android:layout_width="381dp"
+            android:layout_width="match_parent"
+            android:layout_height="32dp"
+            android:layout_marginTop="20dp"
+            android:layout_marginBottom="3dp"
+            android:layout_marginEnd="2dp"
+            android:layout_marginLeft="1dp"
+            android:layout_marginRight="2dp"
+            android:layout_marginStart="1dp"
+            android:text="ともだち"
+            android:textSize="24sp"
+            android:background="@color/colorPrimaryDark"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/ownNameText"
+            tools:text="ともだち" />
+
+        <ListView
+            android:id="@+id/friendList"
+            android:layout_width="0dp"
+            android:layout_height="200dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/friendListTextView"
+            app:layout_constraintVertical_bias="1.0" />
+
+        <TextView
+            android:id="@+id/groupListTextView"
+            android:layout_width="match_parent"
             android:layout_height="32dp"
             android:layout_marginBottom="3dp"
             android:layout_marginEnd="2dp"
             android:layout_marginLeft="1dp"
             android:layout_marginRight="2dp"
             android:layout_marginStart="1dp"
-            android:text="Friend List"
+            android:text="グループ"
             android:textSize="24sp"
-            app:layout_constraintBottom_toTopOf="@+id/friendList"
+            android:background="@color/colorPrimaryDark"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/ownNameText"
-            tools:text="Friend List" />
+            app:layout_constraintTop_toBottomOf="@+id/friendList"
+            tools:text="グループ" />
 
         <ListView
-            android:id="@+id/friendList"
+            android:id="@+id/groupList"
             android:layout_width="0dp"
-            android:layout_height="480dp"
-            app:layout_constraintBottom_toBottomOf="parent"
+            android:layout_height="200dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/friendListTextView"
+            app:layout_constraintTop_toBottomOf="@+id/groupListTextView"
             app:layout_constraintVertical_bias="1.0" />
 
         <Button

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".SettingFragment">
+    tools:context=".Fragment.SettingFragment">
 
     <!-- TODO: Update blank fragment layout -->
     <!-- <TextView

--- a/app/src/main/res/layout/fragment_talk_list.xml
+++ b/app/src/main/res/layout/fragment_talk_list.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".TalkListFragment">
+    tools:context=".Fragment.TalkListFragment">
 
     <ListView
         android:id="@+id/roomListView"

--- a/app/src/main/res/layout/multiple_choice_friend_list_item.xml
+++ b/app/src/main/res/layout/multiple_choice_friend_list_item.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/icon"
+        android:layout_width="120px"
+        android:layout_height="120px" />
+
+    <CheckedTextView
+        android:id="@+id/nameTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="120px"
+        android:layout_weight="1"
+        android:gravity="center_vertical"
+        android:textAppearance="?android:attr/textAppearanceLarge"
+        android:text="Friend_name"
+        android:textSize="16sp"
+        android:checkMark="?android:attr/listChoiceIndicatorMultiple" />
+
+</LinearLayout>


### PR DESCRIPTION
### このPRでは，
- グループ作成機能の実装
- ローカルDBの適用

を進めました．

### グループを作成するには，
1. フレンド画面の右上「＋」を押下
2. 次の画面でグループのメンバーを選択して，「グループ作成」を押下（このとき，すべてのフレンドが表示されるまでしばらく待ってください．非同期通信でリストを追加していく際にソートするので，そのときに選択された項目があるとずれてしまいます．こちら，ローカルDBを使う，または，フレンド画面の情報をintentで引き継ぎ，通信はしない，などで解決できます）
3. グループ名やアイコンを設定して，「作成」を押下

の手順です．そのあと，トークリストに移ってしばらく待つと作成したグループのルームが追加され（るのを期待し）ます．


### ローカルDBを試すには，
ログイン画面の右下「USE LOCALDB」を押下してから，ログインする．
注意事項としては，
- 今までのデータは反映されません．
- デフォルトは「DON'T USE LOCALDB」モードです．その際，ローカルDBが存在していたら全削除する設定にしてあるので，間違って「USE LOCALDB」を押さないでログインするとそれまでローカルDBに保存していたデータは吹っ飛びます．
- 違うアカウントで同じローカルDBを共有することは考えていないので，最初ローカルDBを作成したアカウントと違うアカウントでログインするとおかしなことになりそう．

以上の理由で，これを試す場合は，これ用の**新しいエミュレータ**で**新規のアカウント**を作成してサインアップするのをおすすめします．

### ローカルDBのいいところとしては，
通信の頻度が抑えられるので，いろいろなところでスムーズになる．
### 悪いところとしては，
同期するのがやたらややこしい．（全部を完璧に同期するのは時間的に無理そうなので，目に見えるところだけ，いい感じにしたい）